### PR TITLE
Add ADHD, Autism and Dyslexia pages (closes #1, #2, #3)

### DIFF
--- a/docs/adhd.md
+++ b/docs/adhd.md
@@ -1,0 +1,207 @@
+# ADHD for IT professionals
+
+ADHD (attention deficit hyperactivity disorder) is a neurodevelopmental condition. It shapes how a person sustains attention, regulates impulses, perceives time, manages working memory, and handles strong emotion. It is not a behavioural choice or a productivity flaw.
+
+Roughly 3 to 4 in every 100 UK adults have ADHD. As of late 2025, only around 2.5% of UK adults have a formal diagnosis, so a large share of the IT workforce is undiagnosed or self-identifying. ADHD is over-represented in technical roles.
+
+This page is for BCS members — engineers, data and security specialists, architects, technical managers, students, and chartered professionals — who want a concise, accurate primer.
+
+## What ADHD is
+
+ADHD is recognised as a neurodevelopmental disorder in both DSM-5 and ICD-11 (code `6A05`). It is lifelong, present from childhood, and persists into adulthood in around three quarters of cases. It is diagnosed when a persistent pattern of inattention, hyperactivity-impulsivity, or both, causes meaningful functional impairment across more than one setting.
+
+DSM-5 describes three presentations:
+
+- **predominantly inattentive** — distractibility, forgetfulness, weak sustained attention, difficulty organising
+- **predominantly hyperactive-impulsive** — restlessness, impulsive decisions, interrupting, low tolerance for low-stimulation tasks
+- **combined** — both clusters present
+
+In adults, hyperactivity often internalises as racing thoughts, restlessness, talkativeness, or a constant need for stimulation rather than visible physical activity.
+
+Emotional dysregulation is now recognised as a core feature, not a side-effect. Many adults also describe **rejection sensitive dysphoria (RSD)** — a sharp, disproportionate emotional response to perceived criticism or rejection. RSD is not a formal diagnosis but is widely reported and clinically discussed.
+
+## How ADHD shows up in technical work
+
+ADHD interacts strongly with the structure of modern IT work. Some of that interaction is positive, some is friction.
+
+Common patterns:
+
+- **hyperfocus** during deep coding, debugging, or learning a new stack — sometimes hours, often at the cost of meals, breaks, or the next meeting
+- **time blindness** — sprint estimates, deadlines, and "this'll take 20 minutes" all systematically wrong in the same direction
+- **task initiation difficulty** — staring at a tidy Jira board and starting nothing, even when the work is interesting
+- **working memory load** under context switching — holding a ticket's full context while juggling a pager alert, a code review, and standup is genuinely expensive
+- **interrupt sensitivity** — Slack, Teams, and email pings as constant context-switch triggers
+- **novelty seeking** — drawn to greenfield, prototypes, incidents, new tools; less drawn to maintenance, documentation, compliance training
+- **emotional load** around code review, performance review, and 360 feedback
+- **on-call fatigue** disproportionate to peers, especially where sleep is already fragile
+
+None of these are character flaws. They are predictable consequences of how ADHD brains regulate attention and arousal.
+
+## Strengths in technical work
+
+A strengths-based view is supported by peer-reviewed research and by major ADHD charities. Strengths do not cancel difficulties — both are real at once — but they are not marketing fluff either.
+
+Common strengths in IT contexts:
+
+- **deep flow / hyperfocus** during engaging implementation or debugging work
+- **divergent debugging** — generating many plausible hypotheses quickly, jumping between layers of the stack
+- **pattern recognition** — useful in incident response, security analysis, data work, code review
+- **comfort under chaos** — calm, fast decisions in incident command and live-site scenarios
+- **novelty tolerance** — well suited to greenfield, R&D, prototyping, early-stage products
+- **systems thinking and lateral connections** — picking up on cross-cutting concerns others miss
+- **resilience** — most adults with ADHD have spent years navigating systems not built for them
+
+A 2024 systematic review identified six recurring ability themes across ADHD employment research: cognitive dynamism, courage, energy, humanity, resilience, and transcendence.
+
+## Common challenges in technical work
+
+The other side of the same brain. Typical pinch points:
+
+- **estimation** — sprint pointing, quarterly planning, "is this a 1-day or 5-day job"
+- **sprint cadence vs time blindness** — two-week rhythms with nothing externalised in between
+- **executive load of keeping a board tidy** — Jira/Linear hygiene, status updates, daily stand-up summaries
+- **large diffs and large PRs** — working memory cost grows non-linearly with PR size and monorepo navigation
+- **meeting-heavy days** — focus fragmentation, meeting fatigue, recovery cost
+- **async vs sync mismatch** — many ADHD professionals strongly prefer async-first written comms; some teams default to sync
+- **on-call sustainability** — disrupted sleep, unpredictable interruptions, and stimulant medication wear-off windows interact badly
+- **performance reviews** — spiky output (huge wins, quiet quarters) under-captured by linear rating frameworks
+- **mandatory low-stimulation work** — compliance modules, repetitive documentation, long policy reviews
+- **transitions** — context-switching between deep work and meetings, or between projects, often more costly than for neurotypical peers
+
+Co-occurring conditions are common: at least 60% of people with ADHD have at least one. Autism (~40% co-occurrence, sometimes called AuDHD), dyslexia and other SpLDs, anxiety, depression, and sleep disorders are the ones most likely to show up alongside ADHD in a technical career.
+
+## Getting a diagnosis in the UK
+
+A GP cannot diagnose ADHD. They refer to a specialist (a psychiatrist or specialist clinical psychologist with ADHD expertise) who runs a structured assessment using tools such as DIVA-5, plus developmental history and, where possible, collateral information.
+
+Three routes:
+
+1. **Standard NHS referral.** Free. Waits vary widely and can run to several years.
+2. **Right to Choose (England only).** A statutory right to choose any NHS-commissioned mental health provider in England. From 1 April 2025, RTC fully covers adult ADHD assessment, diagnosis, prescribing, and titration. The GP must agree the referral is appropriate and send it directly — you cannot self-refer. Typically months rather than years.
+3. **Private assessment.** Self-referral to a private specialist (Psychiatry-UK, ADHD 360, Clinical Partners, others). Typically £500–£1,500 for assessment plus ongoing prescribing fees. A private diagnosis is clinically valid; whether the NHS will enter shared-care prescribing afterwards depends on local ICB policy.
+
+Scotland, Wales, and Northern Ireland use NHS routes only — Right to Choose does not apply.
+
+If you suspect ADHD, the first practical step is still a GP appointment. Bring concrete examples of impact across childhood and adulthood, and across more than one setting (work, study, home).
+
+## Support and treatment
+
+NICE NG87 recommends a combined approach. Most people use more than one of the following.
+
+- **Medication.** Stimulants (methylphenidate, lisdexamfetamine) are usually first-line for adults with significant impairment. Non-stimulants (atomoxetine, guanfacine) are alternatives. Titration and monitoring (BP, HR, weight, mood) are required. Only an ADHD-trained specialist can initiate.
+- **CBT for ADHD.** A NICE-recommended adaptation of CBT, typically 10–14 sessions.
+- **ADHD coaching.** Practical work on planning, time, habits, and self-management. Frequently funded in full by Access to Work.
+- **Lifestyle scaffolding.** Sleep hygiene, regular exercise, externalised reminders, consistent routines.
+- **Peer support.** ADHD UK, ADHD Foundation, ADDISS, ADHD Aware, ADHDadultUK, UKAAN.
+
+This page is not medical advice. For clinical questions, see your GP or the [NHS ADHD page](https://www.nhs.uk/conditions/adhd-adults/).
+
+## Reasonable adjustments — practical examples for tech teams
+
+ADHD typically meets the Equality Act 2010 definition of disability. The duty to make reasonable adjustments applies regardless of formal diagnosis — an employer who knows, or could reasonably be expected to know, that a worker is disabled owes the duty. Failing to make reasonable adjustments is disability discrimination.
+
+What "reasonable" looks like in a tech org is usually some subset of the following.
+
+**Environment**
+
+- noise-cancelling headphones (employer-funded)
+- a permanent (non-hot-desked) workstation, ideally away from high-traffic areas
+- WFH or hybrid by default; choice over which days are in-office
+- choice between single-monitor and multi-monitor setups (more screens are not always better for ADHD)
+- a movement-friendly setup (standing desk, walking pad, fidget tools)
+
+**Time and structure**
+
+- core hours instead of fixed start/finish
+- protected focus blocks (e.g. no-meeting mornings, calendar-blocked deep work)
+- shorter standups, written agendas, and pre-reads for any meeting that needs decisions
+- recorded meetings with captions on, so missed bits can be recovered without social cost
+- fewer concurrent context switches — capping work-in-progress per person
+
+**Engineering practice**
+
+- smaller, more frequent PRs rather than long-lived branches
+- written design docs / RFCs over verbal-only design conversations
+- async-first communication norms (Slack/Teams threads, written decisions in the doc, not just in the meeting)
+- pair programming, mob programming, or body-doubling pairs
+- explicit acceptance criteria on tickets; tickets broken down to a size that fits in working memory
+
+**On-call and incident work**
+
+- longer rotation cycles (e.g. weekly with handover, not always-on)
+- paired on-call where possible
+- recovery time after incidents
+- explicit policy on medication wear-off windows and overnight pages
+
+**Tooling**
+
+- task-management power-features in Linear/Jira/Todoist (saved filters, recurring tasks, automations)
+- calendar-blocking culture that respects focus time
+- ADHD-friendly IDE setups (Pomodoro plugins, focus mode, minimap off, distraction-free editing)
+- dictation and voice tooling where helpful
+
+**Performance and progression**
+
+- review criteria that recognise spiky output across a year, not just the last sprint
+- mistakes addressed via process/tooling change before disciplinary routes
+- phased return after burnout or sick leave
+
+Ask in writing where you can. [Acas — Adjustments for neurodiversity](https://www.acas.org.uk/reasonable-adjustments/adjustments-for-neurodiversity).
+
+## Access to Work — for tech-specific tooling
+
+Access to Work (AtW) is a UK government grant scheme, not a benefit. It does not affect other benefits and does not need repaying. It tops up the employer's reasonable-adjustment duty rather than replacing it.
+
+For IT professionals, AtW commonly funds:
+
+- ADHD coaching (typically 100% funded)
+- assistive technology — focus apps, time-management software, dictation tools, screen filters
+- noise-cancelling headphones and ergonomic kit
+- support workers and travel costs where relevant
+- mental health support via Maximus or Able Futures
+
+Grants up to £66,000 per individual. Processing usually takes up to 12 weeks; faster (~4 weeks) if you are starting a new role. Apply at [gov.uk/access-to-work](https://www.gov.uk/access-to-work).
+
+## CPD, certification, and chartered assessment
+
+Reasonable adjustments apply to mandatory training, certification exams, and chartered assessment routes (CITP, CEng, RITTech) just as they do to day-to-day work. Awarding bodies and professional registers generally allow extra time, separate-room exam settings, rest breaks, and other adjustments with appropriate documentation. Apply early — most processes require evidence and lead time.
+
+## For managers — a short note
+
+If a team member discloses ADHD, or you suspect it:
+
+- you do not need a formal diagnosis to make adjustments — act on disclosed need
+- ask what helps, in writing, and treat it as a working agreement you can iterate on
+- protect focus time and async norms at team level, not just per-person — it is cheaper and benefits everyone
+- separate the question "is this a performance issue?" from "is this an unmet adjustment?" — get the second right before reaching for the first
+- be mindful of RSD when giving feedback: specific, behavioural, and private beats vague-and-public every time
+- recognise spiky output over the year, not just the last sprint
+
+## Language and framing
+
+Both identity-first ("ADHDer", "I'm ADHD") and person-first ("person with ADHD") are accepted. Preference varies — let people self-describe. We default to "people with ADHD" and follow each person's lead. We avoid framings like "suffers from" or "afflicted with", and we avoid moral framings like "just lazy" or "needs to try harder".
+
+## BCS resources and further reading
+
+- BCS, [Neurodivergent in Tech specialist group](https://www.bcs.org/membership-and-registrations/member-communities/neurodivergent-in-tech-specialist-group/)
+- BCS Code of Conduct — duty around equity, diversity, and inclusion
+- NHS, [ADHD in adults](https://www.nhs.uk/conditions/adhd-adults/)
+- NICE, [NG87 ADHD: diagnosis and management](https://www.nice.org.uk/guidance/ng87)
+- NHS Digital, [Adult Psychiatric Morbidity Survey 2023–24 — ADHD chapter](https://digital.nhs.uk/data-and-information/publications/statistical/adult-psychiatric-morbidity-survey/survey-of-mental-health-and-wellbeing-england-2023-24/attention-deficit-hyperactivity-disorder)
+- Acas, [Adjustments for neurodiversity](https://www.acas.org.uk/reasonable-adjustments/adjustments-for-neurodiversity)
+- GOV.UK, [Access to Work](https://www.gov.uk/access-to-work)
+- ADHD UK, [Right to Choose](https://adhduk.co.uk/right-to-choose/)
+- Stack Overflow, [Developer with ADHD? You're not alone](https://stackoverflow.blog/2023/12/26/developer-with-adhd-youre-not-alone/)
+- [Challenges, Strengths, and Strategies of Software Engineers with ADHD (arXiv)](https://arxiv.org/html/2312.05029v1)
+- Strengths and challenges in employment — [systematic review (2024)](https://journals.sagepub.com/doi/10.1177/27546330241287655)
+
+## Where to get help
+
+- talk to your GP for clinical questions or referral
+- in a mental health crisis, call 111 or visit [NHS urgent help](https://www.nhs.uk/mental-health/advice-for-life-situations-and-events/where-to-get-urgent-help-for-mental-health/)
+- [ADHD UK](https://adhduk.co.uk/)
+- [ADHD Foundation](https://www.adhdfoundation.org.uk/)
+- [ADDISS](https://www.addiss.co.uk/) — helpline 020 8952 2800
+- [ADHD Aware](https://adhdaware.org.uk/)
+- [ADHDadultUK](https://www.adhdadult.uk/)
+- [UKAAN](https://www.ukaan.org/) (clinical network)

--- a/docs/autism.md
+++ b/docs/autism.md
@@ -1,0 +1,245 @@
+# Autism: a guide for IT professionals
+
+Autism is a lifelong neurodevelopmental difference. It is not an illness, and there is no cure to seek. About 1 in 70 people in the UK is autistic, and most autistic adults are still undiagnosed. A significant minority of people working in IT are autistic, whether or not they know it or have said so out loud.
+
+This page is for BCS members: autistic people in tech, people who suspect they may be autistic, colleagues, and the engineering managers, tech leads and HR partners who work with them. It draws on UK-authoritative sources (NHS, NICE, National Autistic Society, Autistica, ACAS, the Buckland Review of Autism Employment 2024) and autistic-led research. It does not replace clinical advice — for a diagnosis, talk to your GP.
+
+## What autism is
+
+Autism is a difference in how a brain processes information, attention, sensory input and social signals. The two diagnostic domains in DSM-5 and ICD-11 are:
+
+- persistent differences in social communication and interaction
+- restricted, repetitive patterns of behaviour, interests or activities — including sensory differences
+
+Autism is a spectrum, but not a one-dimensional severity scale. Each autistic person has a "spiky profile" of strengths and support needs that varies across contexts. The same engineer who reverse-engineers a flaky distributed-systems bug over a 9-hour deep-focus session may struggle to follow an unstructured 30-minute standup the next morning. That is not a contradiction — it is the spike.
+
+The community has moved away from "high/low-functioning" and "mild/severe" framings, and from "Asperger's" as a separate label. Use "autistic person" or "autistic engineer". Default to identity-first; respect anyone who states a different preference for themselves.
+
+## How autism shows up at work in IT
+
+Autistic traits are not bugs to be patched. They are real differences in cognition that have predictable upsides and downsides in the way modern tech work is organised.
+
+**Communication and social interaction**
+
+- Preference for direct, literal, written communication. Acceptance criteria on a ticket beat a verbal handover at the coffee machine.
+- Reading tone, sarcasm, facial expression and unwritten team norms can take more conscious effort.
+- Eye contact may be uncomfortable; some autistic people find sustained eye contact actively interferes with listening.
+- Small talk and "vibes-based" stakeholder management can be exhausting in a way that the technical work is not.
+
+**Routine, predictability and change**
+
+- Strong preference for predictable schedules, stable tooling, agreed conventions.
+- Sudden mid-sprint reprioritisation, surprise reorgs, ad-hoc "can you jump on a quick call" pings have a real cognitive cost — bigger than they look from the outside.
+- Deep, durable interests ("special interests", or in autistic-affirming usage "spins") that often align with the technical domain.
+- Stimming — small repetitive movements (rocking, fidgeting, hand-flapping, tapping) — is a self-regulation tool, not a tic to be suppressed. A fidget cube in a code review is doing useful work.
+
+**Sensory processing**
+
+- Around 9 in 10 autistic people experience sensory differences (Autistica). Open-plan offices, hot-desking, fluorescent overhead lighting, hot-mic noise on calls, perfumed colleagues, the smell of microwaved fish in the kitchenette — any of these can cost real cycles.
+- Some senses may be hyposensitive rather than hypersensitive; sensory needs are individual.
+
+**Executive function**
+
+- Task initiation, task switching, time perception and working memory often work differently. Context switches between Slack, email, Jira, the IDE, an incident channel and a 1:1 are not free; each has an executive-function tax.
+- "Inertia" cuts both ways: hard to start, hard to stop. This is part of why interrupting a focused autistic engineer mid-flow is genuinely costly, not just rude.
+
+**Monotropism**
+
+A leading autistic-led theory (Murray, Lesser and Lawson, 2005) is that autistic attention tends to channel deeply into a small number of interests at once, rather than spreading thinly across many. Monotropism is a useful frame for engineering managers: it predicts both the deep-focus flow states autistic engineers are valued for, and the cost of yanking them out of those states for an unscheduled meeting.
+
+## Strengths in technical work
+
+Strength-based framings are well-supported by autistic-led organisations and recent software-engineering research (including the 2025 arXiv study *Investigating the Experience of Autistic Individuals in Software Engineering* and Auticon's industry data; the Buckland Review cites employer-reported productivity uplifts of 45-145% in some neurodiverse teams). Autistic engineers commonly bring:
+
+- pattern recognition and anomaly detection — useful in code review, debugging, security analysis, observability and incident response
+- systems thinking and comfort with formal/logical systems — type systems, protocols, RFCs, formal methods, distributed-systems reasoning
+- monotropic deep focus — sustained engagement with hard problems past the point most people context-switch away
+- attention to detail in code review and spec review; low tolerance for hand-waving in a design doc
+- honesty and directness — useful in postmortems and in pushing back on bad technical decisions
+- a strong sense of fairness, which often shows up as principled engineering ethics, fair code-review culture, and refusal to ship things that harm users
+- consistency and conscientiousness — keeping CI green, keeping conventions enforced, owning the unglamorous infrastructure
+- a security mindset; comfort modelling adversaries and edge cases
+- strong written communication — design docs, RFCs, runbooks, incident write-ups
+- deep, durable subject-matter expertise in areas of interest
+
+None of this means autistic people are "natural" engineers, or that all autistic people enjoy the same kinds of work. It means tech contains a lot of work that is well-suited to a lot of autistic people, when the environment lets them do it.
+
+## Common challenges in technical work
+
+What disables autistic people in tech is usually the environment, not the neurology. The Buckland Review (2024) found only 35% of autistic employees feel able to be fully open about being autistic, 1 in 10 disclose to no one, and over a quarter who requested adjustments were refused. Common pain points reported by autistic people working in IT include:
+
+- **Open-plan offices and hot-desking.** Constant low-level sensory load; no way to predict who will be sat next to you. Often the single biggest accessibility blocker.
+- **Unstructured meetings.** Standups that drift, retros without a facilitator, design discussions held only verbally with no written artefact, "quick syncs" with no agenda.
+- **Ambiguous tickets and vague requirements.** "Make it better", "users want this to be smoother", tickets without acceptance criteria.
+- **Sudden plan changes mid-sprint.** Reprioritisation by Slack DM, scope changes that are not written down, on-call schedules shuffled at short notice.
+- **Context-switch load.** Slack, email, Jira, IDE, incident channel, 1:1, design review, retro, all-hands — every switch costs.
+- **Camera-on culture and forced socials.** Mandatory video, off-sites, escape rooms, pub-based team bonding, performative "fun".
+- **Performance frameworks that reward self-promotion.** Calibration cultures and stack-ranking that penalise people who are not comfortable selling their work, or whose contributions are infrastructural and unglamorous.
+- **Whiteboard interviews and "culture fit" panels.** Optimised for fast verbal social performance under pressure — not the same skill as engineering.
+- **Masking exhaustion.** The cognitive cost of consciously or unconsciously suppressing autistic traits to "pass" — forcing eye contact, scripting small talk, suppressing stims. It is real work, and it does not show up on a timesheet.
+
+## Autistic burnout — what it is, and how to spot it
+
+Autistic burnout is a recognised research construct (Raymaker et al., 2020; 48+ peer-reviewed studies as of 2025). It is not the same as occupational burnout, and it is not the same as depression.
+
+It is defined as a syndrome resulting from chronic life stress and a sustained mismatch between expectations and capacity, without adequate support. It is characterised by:
+
+- pervasive, long-term exhaustion (typically 3+ months)
+- loss of skills and function — sometimes including skills the person previously held reliably (executive function, language, self-care, ability to mask)
+- reduced tolerance to sensory and social input
+
+It often follows a long period of high-masking high-performance — the kind of period a senior IT career frequently demands. The recovery profile is also distinct: it tends to respond to reducing demands, sensory rest, unmasking in safe spaces and reasonable adjustments, more than to the standard "take a holiday and come back" prescription for occupational burnout.
+
+If you are an engineer who has been coping for years and has suddenly hit a wall — finding standups intolerable, code you used to write fluently feeling out of reach, every Teams notification feeling like a physical impact — autistic burnout is worth reading about. Talk to your GP. Reduce demands where you can. Ask for adjustments.
+
+If you are a manager: autistic burnout is not a discipline issue and not a performance issue. Treating it as one will make it worse.
+
+## Getting a diagnosis in the UK
+
+You do not need a formal diagnosis to identify as autistic. Self-identification is widely accepted within the autistic community, particularly given systemic barriers to assessment. A diagnosis can help if you want to formalise reasonable adjustments, access certain services, or have a clear answer for yourself.
+
+Routes in the UK:
+
+- **NHS referral.** Ask your GP to refer you to the local NHS adult autism assessment service. As of late 2023, around 143,000 people were waiting for an NHS assessment in England, with many waits over 1-2 years.
+- **NHS Right to Choose (England only).** You can ask your GP to refer you to any NHS-contracted provider in England (for example Psychiatry-UK, ProblemShared, Psicon, Clinical Partners). Waits are typically shorter — currently in the 9-18 month range, but variable. Right to Choose is not available in Scotland, Wales or Northern Ireland.
+- **Private assessment.** Faster, but you pay (typically £1,200-£2,500). A reputable private diagnosis should be accepted by the NHS and employers, though some shared-care arrangements (e.g. for ADHD medication if you also have ADHD) require additional NHS confirmation.
+
+The NICE-recommended adult screening tool is the AQ-10; a score of 6+ warrants a comprehensive assessment. Full assessment usually involves a clinical interview, developmental history, and structured tools such as ADOS-2 and ADI-R.
+
+For current NHS guidance, see [nhs.uk/conditions/autism](https://www.nhs.uk/conditions/autism/).
+
+## Support
+
+There is no cure for autism, and you do not need one. Useful support is about self-understanding, reducing avoidable barriers, and treating any co-occurring conditions on their own terms.
+
+Helpful kinds of support include:
+
+- learning about autism from autistic people and autistic-led communities
+- post-diagnostic peer groups
+- talking therapy adapted for autistic people (some standard CBT protocols do not transfer well unmodified)
+- occupational therapy for sensory needs
+- treatment for co-occurring conditions where appropriate — anxiety, depression, ADHD (around 30-80% of autistic people have ADHD traits), OCD, PTSD, hypermobility-related conditions
+- workplace adjustments and Access to Work funding (see below)
+- autism-specific job coaching or mentoring
+
+Approaches to avoid: ABA-style behaviour modification programmes that aim to suppress visible autistic traits (forcing eye contact, extinguishing stims). Most autistic-led organisations oppose these, and there is growing evidence linking them to trauma.
+
+## Reasonable adjustments — practical examples for tech teams
+
+Autism is a disability under the **Equality Act 2010**, regardless of whether the autistic person personally identifies as disabled. UK employers have a legal duty to make reasonable adjustments to remove substantial disadvantage. "Reasonable" depends on the size and resources of the employer, the cost, and the impact. Most adjustments useful to autistic IT workers are cheap or free.
+
+Concrete examples that map to how tech actually works:
+
+**Communication and process**
+
+- Async-first defaults: written specs, design docs and RFCs over verbal-only design discussions
+- Agendas circulated before meetings; written follow-ups with decisions and action owners
+- Recordings and live captions on calls
+- Explicit, testable acceptance criteria on tickets — not "make it better"
+- Structured code-review templates and conventions (so reviews are about the code, not about reading the reviewer's mood)
+- Written role expectations and progression criteria, not "you'll know it when you see it"
+- Direct, literal feedback in writing; no surprise reviews
+- Permission to default to chat over voice; eye-contact-optional and camera-optional 1:1s
+- A clear escalation path for raising adjustment needs without going through a line manager who may also be the source of the issue
+
+**Workspace and sensory**
+
+- Hybrid or fully remote working where the role allows
+- A fixed desk in a low-stimulus area; opt-out from hot-desking
+- Noise-cancelling headphones, and explicit permission to wear them in meetings and on the floor
+- Lighting control — softer lighting, blinds, screen filters, tinted glasses
+- Single-monitor vs multi-monitor by preference; some autistic engineers focus better with fewer screens, some with more
+- Permission to stim openly; access to fidget tools
+- A quiet space to recover after high-load events (incidents, all-hands, customer calls)
+
+**Schedule and workload**
+
+- Predictable working hours; flexible or staggered start times
+- Advance notice of changes — to schedule, scope, attendees, tooling
+- Shorter, more frequent breaks; sensory recovery time after meetings
+- On-call accommodations: predictable rotations published well in advance, paired on-call where possible, opt-out from secondary on-call during periods of high demand elsewhere
+
+**Recruitment and progression**
+
+- Interview questions sent in advance
+- Take-home or pair-programming exercises in place of whiteboard interviews
+- Written follow-up rounds where possible
+- Choice of interview format, including video off
+- Extra time and a separate room for any timed assessment, with documentation
+- Clear, written progression criteria for promotion
+
+**Training, certification and chartered assessment**
+
+- Reasonable adjustments apply to mandatory training, internal certification, vendor exams (AWS, Azure, GCP, CISSP, etc.) and BCS chartered assessment routes (CITP, CEng, RITTech). Awarding bodies generally allow extra time, separate room, breaks, and written-only formats with appropriate documentation.
+- The chartered assessment **professional review interview** is itself a setting in which adjustments can and should be requested. You do not need to mask your way through it.
+
+**Access to Work**
+
+[Access to Work](https://www.gov.uk/access-to-work) is a UK government grant (DWP) that funds practical support beyond what an employer would reasonably be expected to provide. It is available in England, Scotland and Wales, with an equivalent scheme in Northern Ireland. For autistic IT workers it can fund:
+
+- assistive software (mind-mapping tools, focus and time-tracking software, transcription, screen readers, AAC tools)
+- sensory kit (noise-cancelling headphones, ergonomic and sensory-friendly equipment)
+- communication coaching and autism-specific job coaching
+- autism mentoring
+- mental-health support
+- workplace assessments
+- help with travel to work
+
+Apply at [gov.uk/access-to-work](https://www.gov.uk/access-to-work) or call 0800 121 7479.
+
+## For managers: a short note
+
+If someone on your team has disclosed they are autistic — or has asked for any of the adjustments above without disclosing — the useful posture is: believe them, write things down, default to async, and reduce ambiguity wherever you reasonably can. None of this is "special treatment". Most of it is also good engineering practice. Many of the adjustments listed above (written specs, agendas, recorded meetings, explicit acceptance criteria, predictable on-call) make your whole team faster.
+
+You do not need to know whether someone is "really" autistic. You do not need a diagnosis letter to act on a request. The Equality Act standard is "reasonable", not "verified".
+
+The BCS Code of Conduct includes a duty around equity, diversity and inclusion. This is part of what that looks like in practice on a tech team.
+
+## A note on language
+
+Default to identity-first: "autistic person", "autistic engineer". The largest UK study of community language preferences (Kenny et al., 2016, n=3,470) found "autistic" was the term most strongly endorsed by autistic adults, family members and friends. Some autistic people prefer person-first ("person with autism"); respect individual preference where stated.
+
+Avoid:
+
+- "suffers from autism", "afflicted with autism"
+- "high-functioning" / "low-functioning"
+- "mild" / "severe" autism
+- "Asperger's" as a current label
+- puzzle-piece imagery (associated with Autism Speaks; widely rejected by the autistic community)
+
+The rainbow infinity symbol is the preferred neurodiversity emblem.
+
+## Where to get help
+
+- **Your GP** — for referral or to discuss how you are feeling
+- **Samaritans** — free, 24/7, on **116 123**, if you are in distress
+- **Mind** — mental health support: [mind.org.uk](https://www.mind.org.uk)
+- **National Autistic Society helpline** — [autism.org.uk](https://www.autism.org.uk)
+
+If you are in a mental health crisis, call **999** or go to A&E.
+
+## BCS resources and further reading
+
+**BCS**
+
+- [BCS Neurodivergent in Tech specialist group](https://www.bcs.org/membership-and-registrations/member-communities/neurodivergent-in-tech-specialist-group/) — community of practice within BCS for neurodivergent members and allies
+- BCS Code of Conduct — duty around equity, diversity and inclusion
+
+**UK authoritative**
+
+- NHS, *What is autism?* — [nhs.uk/conditions/autism/what-is-autism](https://www.nhs.uk/conditions/autism/what-is-autism/)
+- NHS, *Signs of autism in adults* — [nhs.uk/conditions/autism/signs/adults](https://www.nhs.uk/conditions/autism/signs/adults/)
+- National Autistic Society — [autism.org.uk](https://www.autism.org.uk/advice-and-guidance/what-is-autism)
+- Autistica — [autistica.org.uk](https://www.autistica.org.uk/what-is-autism/what-is-autism)
+- NICE Guideline CG142, *Autism in adults* — [nice.org.uk/guidance/cg142](https://www.nice.org.uk/guidance/cg142)
+- ACAS, *Reasonable adjustments at work* — [acas.org.uk/reasonable-adjustments](https://www.acas.org.uk/reasonable-adjustments)
+- ACAS, *Adjustments for neurodiversity* — [acas.org.uk/reasonable-adjustments/adjustments-for-neurodiversity](https://www.acas.org.uk/reasonable-adjustments/adjustments-for-neurodiversity)
+- GOV.UK, *Access to Work* — [gov.uk/access-to-work](https://www.gov.uk/access-to-work)
+- GOV.UK, *The Buckland Review of Autism Employment* (2024) — [gov.uk Buckland Review](https://www.gov.uk/government/publications/the-buckland-review-of-autism-employment-report-and-recommendations/the-buckland-review-of-autism-employment-report-and-recommendations)
+
+**Research**
+
+- Kenny et al. (2016), *Which terms should be used to describe autism?* — [Sage](https://journals.sagepub.com/doi/abs/10.1177/1362361315588200)
+- Murray, Lesser and Lawson (2005), *Attention, monotropism and the diagnostic criteria for autism* — [Sage](https://journals.sagepub.com/doi/10.1177/1362361305051398)
+- Raymaker et al. (2020), *Defining Autistic Burnout* — [PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC7313636/)
+- *Investigating the Experience of Autistic Individuals in Software Engineering* (2025) — [arXiv](https://arxiv.org/html/2511.02736v1)

--- a/docs/dyslexia.md
+++ b/docs/dyslexia.md
@@ -1,0 +1,212 @@
+# Dyslexia
+
+Dyslexia is a common cognitive difference that primarily affects word-level reading, spelling and written language. Around 1 in 10 people in the UK are dyslexic. It is lifelong, neurobiological, and unrelated to intelligence.
+
+This page is written for BCS members working in technical roles — software, infrastructure, data, security, architecture, technical management, and students on accredited degrees. It explains what dyslexia is, how it shows up in technical work, the tools and adjustments that help, how to get assessed in the UK, and where to go for more.
+
+It is not medical advice. For clinical questions speak to your GP. For dyslexia-specific guidance contact the [British Dyslexia Association](https://www.bdadyslexia.org.uk/).
+
+## What dyslexia is
+
+Dyslexia is a specific learning difficulty (SpLD) — increasingly described as a specific learning difference. It primarily affects:
+
+- accurate and fluent word-level reading
+- spelling
+- aspects of written language
+
+The dominant cognitive account is a deficit in phonological processing, often alongside slower verbal processing speed and reduced verbal working memory. It exists on a continuum: there is no clean cut-off, and every dyslexic person's profile is different.
+
+Dyslexia frequently co-occurs with ADHD, dyspraxia (DCD), dyscalculia, DLD and autism. Co-occurrence is the norm, not the exception.
+
+## How dyslexia shows up in technical work
+
+Many dyslexic engineers describe the same pattern: the conceptual work is fine, sometimes a strength, but the text-handling tax is high. Typical experiences include:
+
+- reading a long RFC, design doc, ADR or incident postmortem takes longer and burns more working memory than colleagues seem to spend
+- a 600-line PR diff is exhausting to review carefully, especially with poorly-named variables or single-letter identifiers
+- writing tickets, PR descriptions and runbooks feels disproportionately effortful
+- typing speed and accuracy lag behind thinking speed; commit messages and Slack threads accumulate typos
+- Slack-thread overload at the start of the day, or after a long meeting, is genuinely fatiguing
+- live whiteboarding of pseudocode in interviews, or written-exam certifications under time pressure, perform worse than the underlying ability would suggest
+- sequencing pain: keeping a clean commit history, ordering steps in a runbook, reciting a multi-step CLI incantation from memory
+- spelling-sensitive work bites — variable names, CLI flags, env vars, regexes, URLs, secret IDs
+- on-call: parsing dense alerts and dashboards under pressure is a known stressor
+- compliance, contract and policy text (DPIAs, DPAs, ISO/SOC controls) is heavier going than the technical content
+
+None of this is about capability. It is about where the cost lands.
+
+## Strengths in technical work
+
+Dyslexic thinking maps well onto a lot of what senior IT work actually rewards. Commonly reported strengths include:
+
+- **Visual-spatial reasoning** — system design, architecture diagrams, holding a multi-service topology in your head
+- **Pattern recognition** — debugging, threat modelling, anomaly detection, spotting the shape of a regression across logs
+- **Big-picture systems thinking** — seeing cross-component interactions and second-order effects
+- **Strong abstraction skills** — collapsing detail into the right model
+- **Comfort holding multi-component mental models** — useful for distributed systems, incident command, refactors
+- **Narrative reasoning** — writing user-facing copy, runbooks, postmortems that read like a story
+- **Creative / divergent problem-solving** — non-obvious solutions, lateral thinking
+- **Strong verbal reasoning** that often complements weaker decoding — many dyslexic engineers are excellent at explaining complex things out loud
+
+LinkedIn formally added "Dyslexic Thinking" as a skill in 2022. A 2025 empirical study of dyslexic software engineers (arXiv 2511.00706) found self-reported divergent and visual thinking as on-the-job strengths.
+
+## Tools that already help
+
+A lot of mainstream IT tooling is already, in effect, dyslexia accommodation. Make the most of it.
+
+**In the IDE**
+
+- spell-check on identifiers, strings and comments (e.g. Code Spell Checker for VS Code, built-in JetBrains spelling)
+- lint-on-save, format-on-save, rename-symbol refactors — remove the cost of getting names exactly right first time
+- AI assistants (Copilot, Claude, Cursor, Continue) for drafting, refactoring, summarising and rubber-ducking
+- readable themes and fonts: high-contrast-but-not-pure-white themes, generous line height, monospaced fonts with disambiguated glyphs (JetBrains Mono, Fira Code, Cascadia Code). Some prefer OpenDyslexic or Atkinson Hyperlegible for prose panes; evidence for dyslexia-specific fonts is mixed, so try and see
+
+**Reading long-form text**
+
+- text-to-speech for RFCs, postmortems, long PR descriptions and policy text — NaturalReader, macOS Speech, Edge Read Aloud, Speechify
+- AI summarisation for design docs, long Slack threads, meeting transcripts and standup notes
+- read-it-later tools (Pocket, Readwise Reader) with reflow, font and spacing control
+- browser plugins for screen tinting, reflow or Bionic Reading where they help
+
+**Writing**
+
+- voice-to-text for tickets, Slack and email — macOS dictation, Windows Voice Access, Whisper-based tools (e.g. Superwhisper, MacWhisper)
+- Grammarly / LanguageTool for written comms
+- structured templates for PRs, ADRs, RFCs, runbooks, incident reports — reduces blank-page tax
+- AI assistants to draft, tighten and proofread
+
+**Thinking and design**
+
+- mind-mapping and whiteboarding tools (Miro, Whimsical, Excalidraw, FigJam) for architecture and planning
+- diagrams-as-code (Mermaid, PlantUML, D2) when text is easier than a drag-and-drop canvas
+
+If you are a dyslexic engineer reading this and have not deliberately set up your IDE, dictation, TTS and AI-assistant stack — that is probably the highest-leverage hour you will spend this quarter.
+
+## Getting an assessment in the UK
+
+Dyslexia is not a medical diagnosis. GPs cannot diagnose it, and the NHS rarely funds adult dyslexia assessments — a few regional pathways exist but availability is patchy.
+
+A formal diagnostic assessment is carried out by:
+
+- a specialist teacher with a current Assessment Practising Certificate (APC), or
+- an educational or occupational psychologist
+
+They work to standards set by the [SpLD Assessment Standards Committee (SASC)](https://www.sasc.org.uk/) and produce a SASC-format report. That report is what employers, awarding bodies and DSA expect to see.
+
+Indicative private costs (BDA, 2025): specialist teacher around £690, psychologist around £882, wider market roughly £300–£900.
+
+Funding routes:
+
+- self-funded
+- employer-funded (often as a reasonable adjustment — many tech employers will pay)
+- Disabled Students' Allowance (DSA) for higher education students, including those on BCS-accredited degrees
+- Access to Work may contribute toward workplace assessment of needs (separate from a diagnostic assessment)
+- BDA bursaries (limited)
+
+Online screeners can indicate likelihood. They are not diagnostic.
+
+## Your rights and reasonable adjustments
+
+Dyslexia is recognised as a disability under the **Equality Act 2010** where it has a substantial and long-term effect on day-to-day activities. Case law (e.g. *Kumulchew v Starbucks*, 2016) confirms dyslexia routinely meets this threshold.
+
+Employers must:
+
+- not discriminate (direct, indirect, by association, perception, or arising from disability)
+- make reasonable adjustments — the duty applies from recruitment through to dismissal
+- prevent harassment
+
+You do not need a formal diagnosis to ask for adjustments, but a SASC report makes the conversation easier and is usually expected for things like extra time in formal exams.
+
+## Reasonable adjustments — practical examples for tech teams
+
+Concrete adjustments that tend to land well in IT environments:
+
+**Tooling and equipment**
+
+- licences for assistive software: TTS, dictation (Dragon, Whisper-based), Grammarly Business, mind-mapping
+- second monitor; adjustable font, theme and zoom across tools
+- noise-cancelling headphones; quiet space or hybrid/WFH option
+- dyslexia-aware code style guide: meaningful names, modular code, doc comments
+
+**Process and ways of working**
+
+- written role expectations alongside verbal ones; objectives in writing
+- structured templates for PRs, ADRs, RFCs, runbooks, postmortems
+- agendas in advance; minutes, action items and decisions captured in writing
+- meeting recordings with transcripts; captions on by default
+- async-first comms where the work allows — reduces realtime reading load
+- longer review windows for dense documents; paired code review for big diffs
+- reduced reliance on live whiteboarding in interviews — offer take-homes or pair-programming
+- generous time on technical written exams and certification assessments
+- on-call adjustments where reading dense alerts under pressure is a known stressor — e.g. paired on-call during ramp-up, escalation buddy, dashboards optimised for scannability
+- review cycles that don't penalise typos in informal channels
+
+**Career progression**
+
+- written follow-ups to verbal feedback in 1:1s and performance reviews
+- support for chartered routes and certifications (see below)
+
+Adjustments work best when they are tailored. The starting question is "where does the cost actually land for you?", not a checklist.
+
+## Access to Work
+
+[Access to Work](https://www.gov.uk/access-to-work) is a UK government grant scheme, separate from and on top of the employer's duty to make reasonable adjustments. It commonly funds, for dyslexic workers:
+
+- assistive software (TTS, dictation, mind-mapping, advanced spell-check)
+- dyslexia-specialist 1:1 workplace coaching and strategy support
+- specialist equipment
+- a workplace needs assessment
+
+Eligibility: 16+, paid job (or about to start one), employer based in England, Scotland or Wales. Grants don't need to be repaid and don't affect other benefits.
+
+## BCS-specific notes
+
+**Neurodivergent in Tech specialist group.** BCS hosts a [Neurodivergent in Tech specialist group](https://www.bcs.org/membership-and-registrations/member-communities/neurodivergent-in-tech-specialist-group/) with events, talks and a peer network. Worth joining if you want community alongside the practical guidance here.
+
+**BCS Code of Conduct.** The Code includes a duty around equity, diversity and inclusion. That covers your obligations to dyslexic colleagues, candidates and users — for example, in how you run interviews, write technical documentation, and design accessible products.
+
+**CPD, certifications and chartered assessment.** Reasonable adjustments apply to mandatory training, BCS-accredited certification exams and the chartered assessment routes (CITP, CEng, RITTech). Awarding bodies generally allow extra time, separate rooms, screen-reader software, and reader/scribe support, with documentation. The professional review interview can usually be supplemented with written follow-ups. Ask in advance — the earlier you flag it, the smoother it is.
+
+**Accredited degree students.** If you are on a BCS-accredited degree, your university disability service plus DSA is usually the fastest route to assessment funding and study-support tooling.
+
+## For managers — a short note
+
+If a team member discloses dyslexia to you:
+
+- thank them; disclosure is not automatic
+- ask what helps, don't assume — profiles vary widely
+- get the practical things in place quickly: licences, templates, written follow-ups, recording/transcripts, sensible review windows
+- separate "spelling and typing accuracy in informal channels" from "engineering judgement" in performance reviews
+- keep it confidential unless they tell you otherwise
+- if recruitment is involved, default to take-home or pairing over live whiteboarding, and offer extra time on written assessments
+
+If you manage on-call or incident response, think about how dense alerts and runbooks land under pressure. Scannable dashboards and well-structured runbooks help everyone, dyslexic or not.
+
+## Language
+
+Many dyslexic adults prefer identity-first language — "dyslexic engineer", "I am dyslexic". Some prefer person-first — "person with dyslexia". Default to identity-first; respect individual preference. Never use "suffers from". Dyslexia is unrelated to intelligence and many dyslexic professionals view their cognitive style as a strength.
+
+## Where to get help
+
+- **British Dyslexia Association helpline** — 0333 405 4555
+- **NHS** — general health information: [nhs.uk/conditions/dyslexia](https://www.nhs.uk/conditions/dyslexia/)
+- **Your GP** — cannot diagnose dyslexia, but can rule out other things and signpost
+- **Samaritans** — 116 123, if you are struggling with your mental health
+
+## BCS resources and further reading
+
+- [BCS — Neurodivergent in Tech specialist group](https://www.bcs.org/membership-and-registrations/member-communities/neurodivergent-in-tech-specialist-group/)
+- [BCS — Why dyslexics make good coders](https://www.bcs.org/articles-opinion-and-research/why-dyslexics-make-good-coders/)
+- [British Dyslexia Association — What is dyslexia](https://www.bdadyslexia.org.uk/dyslexia/about-dyslexia/what-is-dyslexia)
+- [British Dyslexia Association — Signs of dyslexia in adults](https://www.bdadyslexia.org.uk/advice/adults/am-i-dyslexic/signs-of-dyslexia)
+- [British Dyslexia Association — Diagnostic assessments](https://www.bdadyslexia.org.uk/services/assessments/diagnostic-assessments/overview)
+- [British Dyslexia Association — Employer guidance](https://www.bdadyslexia.org.uk/advice/employers/how-can-i-support-my-dyslexic-employees/legislation)
+- [SASC — find a qualified assessor](https://www.sasc.org.uk/)
+- [gov.uk — Access to Work](https://www.gov.uk/access-to-work)
+- [gov.uk — Definition of disability under the Equality Act 2010](https://www.gov.uk/definition-of-disability-under-equality-act-2010)
+- [gov.uk — Disabled Students' Allowance](https://www.gov.uk/disabled-students-allowance-dsa)
+- [ACAS — Neurodiversity at work](https://www.acas.org.uk/neurodiversity-at-work)
+- [Made By Dyslexia — Workplace](https://www.madebydyslexia.org/workplace/)
+- [Helen Arkell Dyslexia Charity](https://www.helenarkell.org.uk/)
+- [International Dyslexia Association — Definition](https://dyslexiaida.org/definition-of-dyslexia/)
+- [arXiv 2511.00706 — Empirical Investigation of the Experiences of Dyslexic Software Engineers](https://arxiv.org/abs/2511.00706)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,3 +7,7 @@ theme:
 nav:
   - 'index.md'
   - 'committee.md'
+  - 'Neurodiversity':
+      - 'What is ADHD?': 'adhd.md'
+      - 'What is Autism?': 'autism.md'
+      - 'What is Dyslexia?': 'dyslexia.md'


### PR DESCRIPTION
## What

Adds three high-level neurodiversity pages to the site, one per requested condition:

- **What is ADHD?** (`docs/adhd.md`)
- **What is Autism?** (`docs/autism.md`)
- **What is Dyslexia?** (`docs/dyslexia.md`)

They are grouped under a new **Neurodiversity** navigation section in `mkdocs.yml`.

## Why

Resolves the three open page requests:

- Closes #1 (What is ADHD?)
- Closes #2 (What is Autism?)
- Closes #3 (What is Dyslexia?)

Each issue asks for a high-level overview, links to other resources, and reasonable
adjustments/accommodations — all three are covered on every page.

## Source of the copy

Each issue's comments contain three maintainer-written drafts (research notes, a
plain-English gov.uk-style draft, and a BCS-audience technical draft). These pages use the
**BCS-audience drafts**, which match the site's audience of working IT professionals,
students on accredited degrees, and chartered members. The reviewer scaffolding
(`> A revision of…` blockquotes and `*Style notes for reviewers…*`) has been stripped; the
page copy is otherwise verbatim from the issues.

## Verification

- `mkdocs build --strict` passes — the three pages are correctly wired into `nav` and there
  are no broken internal links or build warnings.
- Verified locally with `mkdocs serve`: the **Neurodiversity** tab renders with all three
  sub-pages, headings, reasonable-adjustments sections, and external links.

## Notes

- Content only — no build/theme changes.
- The pre-existing `docs/Initiatives.md` remains out of `nav`, unchanged.
