### PR TITLE
Only run CI on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci 
-on: push
+on:
+  push:
+    branches:
+      - main
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
## Summary

Restricts the `ci` workflow to only trigger on pushes to the `main` branch.

Previously `on: push` fired on every push to any branch, redeploying the site unnecessarily (and running `mkdocs gh-deploy --force` from non-main branches).

## Changes

- `.github/workflows/ci.yml`: scope the `push` trigger to `branches: [main]`