### PR TITLE
Add Events section: reproduce BCS NeurodiverseIT past events (#13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .cache
+site/

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,128 +1,295 @@
 # Past Events
 
-Write-ups and recordings of webinars and events hosted by — or co-hosted with — the
-BCS NeurodiverseIT specialist group. Many sessions are recorded; where a recording
-exists you'll find it embedded on the event's page. This archive mirrors the
-[NeurodiverseIT past events listing on bcs.org](https://www.bcs.org/membership-and-registrations/member-communities/neurodiverseit-specialist-group/past-events/).
-
 ## 2026
 
+<div class="event-card" markdown="1">
 ### [Embracing Neurodiversity and the Future of Project Teams](events/2026-05-embracing-neurodiversity-and-the-future-of-project-teams.md)
-19 May 2026 · Hybrid event · with Project Management SG
-How to recognise and harness neurodiversity for ethical, effective project delivery.
 
+19 May 2026 · Hybrid event · with Project Management SG
+{: .event-meta }
+
+How to recognise and harness neurodiversity for ethical, effective project delivery.
+</div>
+
+<div class="event-card" markdown="1">
 ### [NeurodiverseIT AGM](events/2026-02-neurodiverseit-agm.md)
+
 25 February 2026 · Webinar
+{: .event-meta }
+
 Our annual general meeting — electing the committee and setting priorities for the year.
+</div>
 
 ## 2025
 
+<div class="event-card" markdown="1">
 ### [Starting a Neurodiversity ERG](events/2025-10-starting-a-neurodiversity-erg.md)
+
 30 October 2025 · Webinar
+{: .event-meta }
+
 A roundtable on how to build a neurodiversity Employee Resource Group — the case, governance, sponsorship, and first steps.
 
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/mwBUdxUzm8k" title="Starting an neurodiversity ERG | NeurodiverseIT SG" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+</div>
+
+<div class="event-card" markdown="1">
 ### [Digital vs AI Literacy: Are We Closing the Right Divide?](events/2025-06-digital-vs-ai-literacy.md)
+
 12 June 2025 · Webinar · with Digital Divide SG
+{: .event-meta }
+
 As AI reshapes work, is digital literacy still enough? Unpacking the new skills gap.
 
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/bZmj1wBlooE" title="Digital vs AI Literacy: Are We Closing the Right Divide? | Digital Divide SG" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+</div>
+
+<div class="event-card" markdown="1">
 ### [Celebrating IWD with BCS SIGiST – Thought Leadership in Testing](events/2025-03-iwd-sigist-thought-leadership-in-testing.md)
+
 10 March 2025 · Webinar · with Software Testing SG
+{: .event-meta }
+
 An International Women's Day panel on thought leadership and the future of quality engineering.
 
-### [Neurodiversity in the IT Profession](events/2025-02-neurodiversity-in-the-it-profession.md)
-20 February 2025 · In person, Sheffield · with South Yorkshire Branch
-Neurodivergent professionals share their careers and how to make IT more inclusive.
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/pEeqMlIrHXs" title="Celebrating IWD with BCS SIGiST – Thought Leadership in Testing | Software Testing SG" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+</div>
 
+<div class="event-card" markdown="1">
+### [Neurodiversity in the IT Profession](events/2025-02-neurodiversity-in-the-it-profession.md)
+
+20 February 2025 · In person, Sheffield · with South Yorkshire Branch
+{: .event-meta }
+
+Neurodivergent professionals share their careers and how to make IT more inclusive.
+</div>
+
+<div class="event-card" markdown="1">
 ### [NeurodiverseIT AGM](events/2025-01-neurodiverseit-agm.md)
+
 22 January 2025 · Webinar
+{: .event-meta }
+
 Electing the 2024/25 committee and setting the group's priorities for the year.
+</div>
 
 ## 2024
 
+<div class="event-card" markdown="1">
 ### [Neurodiversity and AI](events/2024-12-neurodiversity-and-ai.md)
+
 3 December 2024 · Webinar
+{: .event-meta }
+
 The opportunities and risks AI brings for neurodivergent people, and a new working group.
+</div>
 
+<div class="event-card" markdown="1">
 ### [Autism and the IT profession — a response to The Buckland Report](events/2024-06-autism-and-the-it-profession-buckland-report.md)
-20 June 2024 · Webinar
-Co-producing a community response to the Government's Buckland Report on autism and employment.
 
+20 June 2024 · Webinar
+{: .event-meta }
+
+Co-producing a community response to the Government's Buckland Report on autism and employment.
+</div>
+
+<div class="event-card" markdown="1">
 ### [Countering dyslexia adverse effects with LLMs like ChatGPT](events/2024-05-countering-dyslexia-with-llms.md)
+
 15 May 2024 · Webinar · with BCS Oxfordshire
+{: .event-meta }
+
 Antonio Hidalgo-Landa on using large language models to support learning differences.
 
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/WOpdoxa9rY4" title="Countering Dyslexia Adverse Effects with Large Language Models (LLMs) like ChatGPT | Oxfordshire" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+</div>
+
+<div class="event-card" markdown="1">
 ### [Neurodivergence and Tech Entrepreneurship](events/2024-04-neurodivergence-and-tech-entrepreneurship.md)
+
 22 April 2024 · Webinar
+{: .event-meta }
+
 Why entrepreneurship can be a viable, autonomy-rich alternative for neurodivergent people.
+</div>
 
+<div class="event-card" markdown="1">
 ### [Digital for all: Building a connected digital inclusion ecosystem in Leeds](events/2024-04-digital-for-all-leeds.md)
+
 16 April 2024 · Webinar · with Digital Divide SG
+{: .event-meta }
+
 How 100% Digital Leeds built one of the UK's most successful digital inclusion programmes.
+</div>
 
+<div class="event-card" markdown="1">
 ### [NeurodiverseIT AGM](events/2024-04-neurodiverseit-agm.md)
-9 April 2024 · Webinar
-Confirming the 2023/24 committee.
 
+9 April 2024 · Webinar
+{: .event-meta }
+
+Confirming the 2023/24 committee.
+</div>
+
+<div class="event-card" markdown="1">
 ### [Experiences of disability and neurodiversity in IT](events/2024-01-experiences-of-disability-and-neurodiversity-in-it.md)
+
 16 January 2024 · Webinar
+{: .event-meta }
+
 A specialist panel on the contribution disabled and neurodivergent people make to the profession.
+</div>
 
 ## 2023
 
+<div class="event-card" markdown="1">
 ### [Who, when and how to share — a personal and professional dilemma](events/2023-10-who-when-and-how-to-share.md)
-30 October 2023 · Webinar
-The dilemma of disclosing neurodivergence at work, and the factors to weigh either way.
 
+30 October 2023 · Webinar
+{: .event-meta }
+
+The dilemma of disclosing neurodivergence at work, and the factors to weigh either way.
+</div>
+
+<div class="event-card" markdown="1">
 ### [Neurodiversity: hidden risks of Equity, Diversity and Inclusion (EDI) data](events/2023-10-hidden-risks-of-edi-data.md)
+
 10 October 2023 · Webinar · with IRMA SG
+{: .event-meta }
+
 Why collecting EDI data carries special privacy risks for invisible minority groups.
 
-### [Neurodiversity in Business — how can you help IT?](events/2023-09-neurodiversity-in-business.md)
-21 September 2023 · Hybrid event · with BCS London branches
-Dan Harris of Neurodiversity in Business on the benefits neurodivergence brings to tech.
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/jzncgMudXpE" title="Neurodiversity, hidden risks of Equity, Diversity and Inclusion (EDI) data | IRMA SG" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+</div>
 
+<div class="event-card" markdown="1">
+### [Neurodiversity in Business — how can you help IT?](events/2023-09-neurodiversity-in-business.md)
+
+21 September 2023 · Hybrid event · with BCS London branches
+{: .event-meta }
+
+Dan Harris of Neurodiversity in Business on the benefits neurodivergence brings to tech.
+</div>
+
+<div class="event-card" markdown="1">
 ### [Using technology to address the digital divide for the visually impaired](events/2023-08-digital-divide-for-the-visually-impaired.md)
+
 17 August 2023 · Webinar · with Digital Divide SG
+{: .event-meta }
+
 Kris Gibson of Southampton Sight on assistive technology for partial and full sight loss.
 
-### [Exploring Neurodivergence in Tech — Sussex Branch & NeurodiverseIT SG](events/2023-04-exploring-neurodivergence-in-tech-sussex.md)
-19 April 2023 · In person · with Sussex Branch
-A panel on the barriers neurodivergent people face in tech, and how to raise awareness.
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/WldVedjOQ6g" title="Using technology to address the digital divide for the visually impaired | Digital Divide SG" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+</div>
 
+<div class="event-card" markdown="1">
+### [Exploring Neurodivergence in Tech — Sussex Branch & NeurodiverseIT SG](events/2023-04-exploring-neurodivergence-in-tech-sussex.md)
+
+19 April 2023 · In person · with Sussex Branch
+{: .event-meta }
+
+A panel on the barriers neurodivergent people face in tech, and how to raise awareness.
+</div>
+
+<div class="event-card" markdown="1">
 ### [Ahead of the curve — Neurodiversity and Business Change](events/2023-02-ahead-of-the-curve.md)
+
 28 February 2023 · Webinar · with Business Change SG
+{: .event-meta }
+
 How embracing neurodiversity increases an organisation's capacity for adaptive change.
 
-### [Closing the Digital Divide — Digital Divide SG one year on AGM](events/2023-02-closing-the-digital-divide-agm.md)
-23 February 2023 · Webinar · with Digital Divide SG
-The Digital Divide SG one year on: purpose, achievements, and plans for 2023.
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/8KkjkSbZfXY" title="Ahead of the curve | Neurodiversity and Business Change" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+</div>
 
+<div class="event-card" markdown="1">
+### [Closing the Digital Divide — Digital Divide SG one year on AGM](events/2023-02-closing-the-digital-divide-agm.md)
+
+23 February 2023 · Webinar · with Digital Divide SG
+{: .event-meta }
+
+The Digital Divide SG one year on: purpose, achievements, and plans for 2023.
+</div>
+
+<div class="event-card" markdown="1">
 ### [NeurodiverseIT SG AGM](events/2023-01-neurodiverseit-agm.md)
+
 18 January 2023 · Webinar
+{: .event-meta }
+
 Confirming the 2022/23 committee and adding new volunteers.
+</div>
 
 ## 2022
 
+<div class="event-card" markdown="1">
 ### [A meeting of Agile and Neurodiverse minds](events/2022-11-agile-and-neurodiverse-minds.md)
+
 10 November 2022 · Webinar · with Agile Methods SG
+{: .event-meta }
+
 Marc Goblot on how Agile principles relate to neuro-inclusive practice.
+</div>
 
+<div class="event-card" markdown="1">
 ### [Digital participation for all: supporting older people](events/2022-10-digital-participation-for-older-people.md)
+
 13 October 2022 · Webinar · with Digital Divide SG
+{: .event-meta }
+
 Professor Leela Damodaran on enabling older people to participate digitally.
+</div>
 
+<div class="event-card" markdown="1">
 ### [NeurodiverseIT SG EGM](events/2022-07-neurodiverseit-egm.md)
+
 13 July 2022 · Webinar
+{: .event-meta }
+
 An extraordinary general meeting to elect a full-strength committee.
+</div>
 
+<div class="event-card" markdown="1">
 ### [Autism — Harnessing my super power](events/2022-04-autism-harnessing-my-super-power.md)
+
 28 April 2022 · Hybrid event · with BCS Oxfordshire
+{: .event-meta }
+
 A personal account of understanding and leveraging autism in an IT career.
+</div>
 
+<div class="event-card" markdown="1">
 ### [Introducing NeurodiverseIT](events/2022-04-introducing-neurodiverseit.md)
-6 April 2022 · Webinar
-The very first event from the new specialist group — who we are and what we hope to achieve.
 
+6 April 2022 · Webinar
+{: .event-meta }
+
+The very first event from the new specialist group — who we are and what we hope to achieve.
+</div>
+
+<div class="event-card" markdown="1">
 ### [Neurodiversity Understood](events/2022-03-neurodiversity-understood.md)
+
 9 March 2022 · Webinar · with BCS London South
+{: .event-meta }
+
 Natasha Catchpole on what it is like to be neurodiverse in a neurotypical world.
+
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/PWpDW_wWP1c" title="Webinar: Neurodiversity Understood | BCS" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+</div>

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,128 @@
+# Past Events
+
+Write-ups and recordings of webinars and events hosted by — or co-hosted with — the
+BCS NeurodiverseIT specialist group. Many sessions are recorded; where a recording
+exists you'll find it embedded on the event's page. This archive mirrors the
+[NeurodiverseIT past events listing on bcs.org](https://www.bcs.org/membership-and-registrations/member-communities/neurodiverseit-specialist-group/past-events/).
+
+## 2026
+
+### [Embracing Neurodiversity and the Future of Project Teams](events/2026-05-embracing-neurodiversity-and-the-future-of-project-teams.md)
+19 May 2026 · Hybrid event · with Project Management SG
+How to recognise and harness neurodiversity for ethical, effective project delivery.
+
+### [NeurodiverseIT AGM](events/2026-02-neurodiverseit-agm.md)
+25 February 2026 · Webinar
+Our annual general meeting — electing the committee and setting priorities for the year.
+
+## 2025
+
+### [Starting a Neurodiversity ERG](events/2025-10-starting-a-neurodiversity-erg.md)
+30 October 2025 · Webinar
+A roundtable on how to build a neurodiversity Employee Resource Group — the case, governance, sponsorship, and first steps.
+
+### [Digital vs AI Literacy: Are We Closing the Right Divide?](events/2025-06-digital-vs-ai-literacy.md)
+12 June 2025 · Webinar · with Digital Divide SG
+As AI reshapes work, is digital literacy still enough? Unpacking the new skills gap.
+
+### [Celebrating IWD with BCS SIGiST – Thought Leadership in Testing](events/2025-03-iwd-sigist-thought-leadership-in-testing.md)
+10 March 2025 · Webinar · with Software Testing SG
+An International Women's Day panel on thought leadership and the future of quality engineering.
+
+### [Neurodiversity in the IT Profession](events/2025-02-neurodiversity-in-the-it-profession.md)
+20 February 2025 · In person, Sheffield · with South Yorkshire Branch
+Neurodivergent professionals share their careers and how to make IT more inclusive.
+
+### [NeurodiverseIT AGM](events/2025-01-neurodiverseit-agm.md)
+22 January 2025 · Webinar
+Electing the 2024/25 committee and setting the group's priorities for the year.
+
+## 2024
+
+### [Neurodiversity and AI](events/2024-12-neurodiversity-and-ai.md)
+3 December 2024 · Webinar
+The opportunities and risks AI brings for neurodivergent people, and a new working group.
+
+### [Autism and the IT profession — a response to The Buckland Report](events/2024-06-autism-and-the-it-profession-buckland-report.md)
+20 June 2024 · Webinar
+Co-producing a community response to the Government's Buckland Report on autism and employment.
+
+### [Countering dyslexia adverse effects with LLMs like ChatGPT](events/2024-05-countering-dyslexia-with-llms.md)
+15 May 2024 · Webinar · with BCS Oxfordshire
+Antonio Hidalgo-Landa on using large language models to support learning differences.
+
+### [Neurodivergence and Tech Entrepreneurship](events/2024-04-neurodivergence-and-tech-entrepreneurship.md)
+22 April 2024 · Webinar
+Why entrepreneurship can be a viable, autonomy-rich alternative for neurodivergent people.
+
+### [Digital for all: Building a connected digital inclusion ecosystem in Leeds](events/2024-04-digital-for-all-leeds.md)
+16 April 2024 · Webinar · with Digital Divide SG
+How 100% Digital Leeds built one of the UK's most successful digital inclusion programmes.
+
+### [NeurodiverseIT AGM](events/2024-04-neurodiverseit-agm.md)
+9 April 2024 · Webinar
+Confirming the 2023/24 committee.
+
+### [Experiences of disability and neurodiversity in IT](events/2024-01-experiences-of-disability-and-neurodiversity-in-it.md)
+16 January 2024 · Webinar
+A specialist panel on the contribution disabled and neurodivergent people make to the profession.
+
+## 2023
+
+### [Who, when and how to share — a personal and professional dilemma](events/2023-10-who-when-and-how-to-share.md)
+30 October 2023 · Webinar
+The dilemma of disclosing neurodivergence at work, and the factors to weigh either way.
+
+### [Neurodiversity: hidden risks of Equity, Diversity and Inclusion (EDI) data](events/2023-10-hidden-risks-of-edi-data.md)
+10 October 2023 · Webinar · with IRMA SG
+Why collecting EDI data carries special privacy risks for invisible minority groups.
+
+### [Neurodiversity in Business — how can you help IT?](events/2023-09-neurodiversity-in-business.md)
+21 September 2023 · Hybrid event · with BCS London branches
+Dan Harris of Neurodiversity in Business on the benefits neurodivergence brings to tech.
+
+### [Using technology to address the digital divide for the visually impaired](events/2023-08-digital-divide-for-the-visually-impaired.md)
+17 August 2023 · Webinar · with Digital Divide SG
+Kris Gibson of Southampton Sight on assistive technology for partial and full sight loss.
+
+### [Exploring Neurodivergence in Tech — Sussex Branch & NeurodiverseIT SG](events/2023-04-exploring-neurodivergence-in-tech-sussex.md)
+19 April 2023 · In person · with Sussex Branch
+A panel on the barriers neurodivergent people face in tech, and how to raise awareness.
+
+### [Ahead of the curve — Neurodiversity and Business Change](events/2023-02-ahead-of-the-curve.md)
+28 February 2023 · Webinar · with Business Change SG
+How embracing neurodiversity increases an organisation's capacity for adaptive change.
+
+### [Closing the Digital Divide — Digital Divide SG one year on AGM](events/2023-02-closing-the-digital-divide-agm.md)
+23 February 2023 · Webinar · with Digital Divide SG
+The Digital Divide SG one year on: purpose, achievements, and plans for 2023.
+
+### [NeurodiverseIT SG AGM](events/2023-01-neurodiverseit-agm.md)
+18 January 2023 · Webinar
+Confirming the 2022/23 committee and adding new volunteers.
+
+## 2022
+
+### [A meeting of Agile and Neurodiverse minds](events/2022-11-agile-and-neurodiverse-minds.md)
+10 November 2022 · Webinar · with Agile Methods SG
+Marc Goblot on how Agile principles relate to neuro-inclusive practice.
+
+### [Digital participation for all: supporting older people](events/2022-10-digital-participation-for-older-people.md)
+13 October 2022 · Webinar · with Digital Divide SG
+Professor Leela Damodaran on enabling older people to participate digitally.
+
+### [NeurodiverseIT SG EGM](events/2022-07-neurodiverseit-egm.md)
+13 July 2022 · Webinar
+An extraordinary general meeting to elect a full-strength committee.
+
+### [Autism — Harnessing my super power](events/2022-04-autism-harnessing-my-super-power.md)
+28 April 2022 · Hybrid event · with BCS Oxfordshire
+A personal account of understanding and leveraging autism in an IT career.
+
+### [Introducing NeurodiverseIT](events/2022-04-introducing-neurodiverseit.md)
+6 April 2022 · Webinar
+The very first event from the new specialist group — who we are and what we hope to achieve.
+
+### [Neurodiversity Understood](events/2022-03-neurodiversity-understood.md)
+9 March 2022 · Webinar · with BCS London South
+Natasha Catchpole on what it is like to be neurodiverse in a neurotypical world.

--- a/docs/events/2022-03-neurodiversity-understood.md
+++ b/docs/events/2022-03-neurodiversity-understood.md
@@ -1,0 +1,20 @@
+# Neurodiversity Understood
+
+**Wednesday 9 March 2022, 6:30pm – 8:30pm · Webinar · with the BCS London South branch**
+
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/PWpDW_wWP1c" title="Webinar: Neurodiversity Understood | BCS" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+It is estimated that 1 in 7 people are neurodiverse, meaning that the brain functions, learns and processes information differently to what society expects.
+
+Come along on the 9th March to discover what it is like to be neurodiverse in a neurotypical world.
+
+Demystify the myths, discover the strengths, uncover the challenges and explore the support, adjustments and strategies available to help neurodiverse thinkers work at their best.
+
+## Speaker
+
+- Natasha Catchpole, psychologist and Director, Neurodiversity Uncovered; 10+ years' experience in neurodiversity
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2022/march/webinar-neurodiversity-understood/).*

--- a/docs/events/2022-04-autism-harnessing-my-super-power.md
+++ b/docs/events/2022-04-autism-harnessing-my-super-power.md
@@ -1,0 +1,14 @@
+# Autism — Harnessing my super power
+
+**Thursday 28 April 2022, 7:30pm · Hybrid event · with the BCS Oxfordshire branch**
+
+*In person at the Oxford e-Research Centre (OeRC), University of Oxford, 6 Keble Road, OX1 3QG, and online via Zoom; the speaker attended remotely.*
+
+Autism has touched my life in many ways, and whilst early in my career it has negatively impacted my career, understanding "why" has enabled me to start to leverage it in my professional career, and more importantly understand "how I tick". How do we, as IT professionals, ensure we are providing an equal playing field for people to compete for opportunities, and building environments for all to thrive?
+
+## Speaker
+
+- A Programme Director with 20 years' experience leading global programmes, recently moved to a global Program Director role at Microsoft, and an Autism Champion within HMRC.
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2022/april/hybrid-event-autism-harnessing-my-super-power/).*

--- a/docs/events/2022-04-introducing-neurodiverseit.md
+++ b/docs/events/2022-04-introducing-neurodiverseit.md
@@ -1,0 +1,14 @@
+# Introducing NeurodiverseIT
+
+**Wednesday 6 April 2022, 7:00pm – 8:30pm · Webinar**
+
+Are you a neurodivergent IT professional, or otherwise interested in neurodiversity? Then join us for the first event from our new specialist group, NeurodiverseIT. During the webinar, we will introduce the new group, share what we hope to achieve, and see how you may be able to help develop our committee. This is an interactive session and there will be plenty of space to hear from you about your interests and priorities for the group.
+
+## Speakers
+
+- Matthew Bellringer, Chair; founding member, 25+ years in technology and service development
+- Richard Cornell, Vice-Chair; founding member, Information Security Manager with 25+ years IT experience
+- Desmond Alvares, Treasurer; founding member, 30+ years in business, project management and IT
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2022/april/webinar-introducing-neurodiverseit/).*

--- a/docs/events/2022-07-neurodiverseit-egm.md
+++ b/docs/events/2022-07-neurodiverseit-egm.md
@@ -1,0 +1,24 @@
+# NeurodiverseIT SG EGM
+
+**Wednesday 13 July 2022, 2:00pm – 3:00pm · Webinar**
+
+We are hosting an EGM (Extraordinary General Meeting) to elect proposed members to the committee of our group.
+
+We have decided to hold this EGM so that we can have a full-strength committee going into the 2022/23 year, and we hope to have further volunteering opportunities soon.
+
+Voting roles include:
+
+- Content officer
+- Member secretary
+- Industry liaison/publicity officer
+- Inclusion officer
+- Early Careers
+- Education liaison
+- Two further roles TBC
+
+Candidate statements will be circulated with the mailing list ahead of the meeting. Please contact neurodiverseit-chair@bcs.org with any volunteering enquiries or in-absentia votes.
+
+The event will take place on Zoom with live captioning available. You can participate in the meeting by text chat, voice and/or video.
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2022/july/webinar-neurodiverseit-sg-egm-extraordinary-general-meeting/).*

--- a/docs/events/2022-10-digital-participation-for-older-people.md
+++ b/docs/events/2022-10-digital-participation-for-older-people.md
@@ -1,0 +1,20 @@
+# Digital participation for all: supporting older people
+
+**Thursday 13 October 2022, 5:00pm – 6:00pm · Webinar · with the Digital Divide specialist group**
+
+IT is now integral to life. Enabling older people to digitally participate is crucial to living autonomously and independently for longer.
+
+IT use is becoming increasingly important in sustaining the independence and autonomy of individuals as they age. Whether it is banking apps, accessing medical services or simply communicating with their grandchildren; older people often want to engage but lack the skills (often physical as well as mental) to do so and frequently feel overwhelmed by the technology.
+
+Without the ability to use IT effectively older people will become increasingly marginalised and dependent, so this session presents research findings on older people's needs, and wants – and considers how can we mobilise the vast assets we have to meet these end-user-specified requirements and capabilities.
+
+The vision is to work together to produce sustainable and inclusive solutions, to provide what older people really want – in a meaningful connection.
+
+## Speaker
+
+- Leela Damodaran, FAcSS, MIoD, Professor Emerita of Digital Inclusion and Participation, Loughborough University
+
+*This event was hosted by the Digital Divide specialist group and supported by BCSWomen, NeurodiverseIT and the Hampshire and Dorset branches.*
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2022/october/webinar-digital-participation-for-all-what-we-can-do-to-support-older-people/).*

--- a/docs/events/2022-11-agile-and-neurodiverse-minds.md
+++ b/docs/events/2022-11-agile-and-neurodiverse-minds.md
@@ -1,0 +1,16 @@
+# A meeting of Agile and Neurodiverse minds
+
+**Thursday 10 November 2022, 6:00pm – 7:30pm · Webinar · with the Agile Methods specialist group**
+
+The aim of this event is to expand everyone's horizons and include more diverse perspectives to make our industry more open and creative, reflecting its crucial role and responsibility in society.
+
+Our guest speaker Marc Goblot, one of the Neurodiversity SG committee members will discuss his involvement in technology and neurodiversity, sharing a quick overview of neurodiversity and why it matters to us in tech. He'll also introduce the new specialist group as part of the BCS's approach to inclusive tech, its objectives, people and emerging plans.
+
+Marc will discuss Agile and how its principles could relate to neuro-inclusive practices. We'll then have time for some conversation on the topics raised, and facilitate a Questions and Answers discussion.
+
+## Speaker
+
+- Marc Goblot, Neurodiversity SG committee member; digital transformation and solution consultant; founder of Tech London Advocates Tech For Disability group; Director at We and AI
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2022/november/webinar-a-meeting-of-agile-and-neurodiverse-minds-agile-methods-sg/).*

--- a/docs/events/2023-01-neurodiverseit-agm.md
+++ b/docs/events/2023-01-neurodiverseit-agm.md
@@ -1,0 +1,23 @@
+# NeurodiverseIT SG AGM
+
+**Wednesday 18 January 2023, 6:00pm · Webinar**
+
+We are holding our AGM to confirm the committee for the 2022/23 year selected at the EGM and add new volunteers.
+
+We will be voting on the following roles at the meeting:
+
+- Chair
+- Treasurer
+- Content officer
+- Member secretary
+- Industry liaison/publicity officer
+- Inclusion officer
+- Early Careers
+- Education liaison
+
+Please contact neurodiverseit-chair@bcs.org with any volunteering enquiries or in-absentia votes.
+
+Our events are for adults aged 16 years and over.
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2023/january/webinar-neurodiverseit-sg-agm-annual-general-meeting/).*

--- a/docs/events/2023-02-ahead-of-the-curve.md
+++ b/docs/events/2023-02-ahead-of-the-curve.md
@@ -1,0 +1,18 @@
+# Ahead of the curve — Neurodiversity and Business Change
+
+**Tuesday 28 February 2023, 6:30pm · Webinar · with the Business Change specialist group**
+
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/8KkjkSbZfXY" title="Ahead of the curve | Neurodiversity and Business Change" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+The pace of systems change necessary for organisations to keep up with their environment is ever-increasing. This doesn't just include anticipated change, but coping with unexpected and unplanned "black swan" events. To make it even harder, there is a lack of people with the skills necessary to enact such change effectively.
+
+In this talk, Matthew Bellringer will share how by embracing neurodiversity, organisations can increase their capacity for successful, adaptive change. We explore how different perspectives contribute to organisational endurance, and how - provided with a supportive environment - neurodivergent people can make a unique contribution at work.
+
+## Speaker
+
+- Matthew Bellringer, background in technology, psychology, research and innovation; Chair of NeurodiverseIT
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2023/february/webinar-ahead-of-the-curve-neurodiversity-and-business-change/).*

--- a/docs/events/2023-02-closing-the-digital-divide-agm.md
+++ b/docs/events/2023-02-closing-the-digital-divide-agm.md
@@ -1,0 +1,25 @@
+# Closing the Digital Divide — Digital Divide SG one year on AGM
+
+**Thursday 23 February 2023, 5:00pm – 6:30pm · Webinar · with the Digital Divide specialist group**
+
+Closing the digital divide is one of four top strategic priorities for BCS. The Digital Divide Specialist Group was formally launch in Feb 2022. One year on, what is its purpose, vision and mission? What has it done to date? What are the plans for 2023? How can anyone get involved?
+
+Come and join us to hear from the committee members about the one thing that they champion. Please stay to attend our AGM to find out about the committee and plans for this year, and volunteer if you want to join the committee.
+
+## Speakers
+
+- Freddie Quek, Chief Technology Officer at Times Higher Education and Chair of the BCS Digital Divide specialist group
+- Fiona Dawson, Director at Mayden
+- Dave Donaghy, software engineer at Hewlett Packard Enterprise
+- Tristi Tanaka, technology transformation professional
+- Mark West, IT Project and Change Management consultant
+- Charlie Houston-Brown, business system consultant and Chair of BCS North Staffordshire Branch
+- Margaret Ross, Emeritus Professor of Software Quality at Solent University
+- Sean Sadler, senior IT leader and Director of Consulting
+- James Davenport, Professor at the University of Bath (Department of Mathematical Sciences and Department of Computer Science)
+- Matthew Bellringer, systems developer and Chair of BCS NeurodiverseIT
+
+*This event was hosted by the Digital Divide specialist group with BCS Hampshire, BCSWomen and NeurodiverseIT.*
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2023/february/webinar-closing-the-digital-divide-digital-divide-sg-one-year-on-agm/).*

--- a/docs/events/2023-04-exploring-neurodivergence-in-tech-sussex.md
+++ b/docs/events/2023-04-exploring-neurodivergence-in-tech-sussex.md
@@ -1,0 +1,15 @@
+# Exploring Neurodivergence in Tech — Sussex Branch & NeurodiverseIT SG
+
+**Wednesday 19 April 2023, 7:00pm · In person · with the BCS Sussex Branch**
+
+We will host a panel discussing the barriers faced by Neurodivergent individuals in the Tech field and how we can raise awareness and support for these issues. The panel will take questions from the audience. This should be of interest to all working in IT including managers, recruiters, and applicants.
+
+## Panellists
+
+- Matthew Bellringer, MBCS MBPsS, systems developer, facilitator, speaker and author
+- Marc Goblot, FRSA, Chair of Greater London Regional Stakeholders Network Disability Unit; Founder of Tech for Disability working group and Ina Ciel
+- Liv Livesey, leads AI skills at the Office for Artificial Intelligence, UK Government
+- Meg Tennies, Junior SQL Developer, National House Building Council (NHBC)
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2023/april/exploring-neurodivergence-in-tech-sussex-branch-neurodiverseit-sg/).*

--- a/docs/events/2023-08-digital-divide-for-the-visually-impaired.md
+++ b/docs/events/2023-08-digital-divide-for-the-visually-impaired.md
@@ -1,0 +1,32 @@
+# Using technology to address the digital divide for the visually impaired
+
+**Thursday 17 August 2023, 5:00pm · Webinar · with the Digital Divide specialist group**
+
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/WldVedjOQ6g" title="Using technology to address the digital divide for the visually impaired | Digital Divide SG" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+How technology can assist those with partial and full sight loss, including sudden loss for daily living and in the work environment.
+
+Whether degenerative or sudden, there is no doubting the impact of sight loss on every aspect of an individual's life. However, with the help of accessibility software, modern apps and a range of technology it has never been easier to bridge the digital divide, support self-reliance, and bring the visually impaired back into the work force.
+
+Join BCS Digital Divide Specialist Group's webinar featuring Kris Gibson from Southampton Sight to discuss supporting the visually impaired community on what, how, and where assistive technology can help them connect to the internet, negotiate smart phones, and retain independence. Himself severely sight impaired, Kris will also touch upon the issues of employment, the support available, and working with sight loss.
+
+This is a free online session. When you attend you'll receive further details of how to join.
+
+You will learn about:
+
+- Sight Loss – A Life Lived Differently
+- Text-To-Speech Software
+- Laptop & Smart Phone Accessibility
+- Electronic Magnifiers + Other Assistive Technologies
+- Access To Work – What, Who and How
+
+## Speaker
+
+- Kris Gibson, Sight Loss Advisor at Southampton Sight
+
+*This event was hosted by the Digital Divide specialist group with BCS Hampshire and Dorset branches.*
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2023/august/webinar-using-technology-to-address-the-digital-divide-for-the-visually-impaired/).*

--- a/docs/events/2023-09-neurodiversity-in-business.md
+++ b/docs/events/2023-09-neurodiversity-in-business.md
@@ -1,0 +1,18 @@
+# Neurodiversity in Business — how can you help IT?
+
+**Thursday 21 September 2023, 6:30pm · Hybrid event · with the BCS London Central, London North and London South branches**
+
+Awareness about neurodivergence has been rising steadily in recent years. At Neurodiversity in Business, a charity that is the leading industry forum facilitating conversations between corporates and the ND community, the focus is on the significant benefits that neurodivergence brings to business.
+
+It is estimated that around 10-15% of the population are neurodivergent – a term that is used to refer to autism, ADHD, Tourettes, Dyslexia, Dyspraxia and others. A significant ability to focus, different problem solving skills and the ability to process information quickly are three of the key business benefits that many ND people bring to the workplace.
+
+In the STEM sector, this proportion of the population may rise to 30% as the skills associated with ND ways of thinking naturally lend themselves to these disciplines. What is the technology sector as a whole doing in this space? How are companies investing in neurodivergent attraction and retention in a highly competitive workplace?
+
+And what does the future of tech hold to help more ND people navigate and prosper in the workplace? Join CEO & Founder of Neurodiversity in Business, Dan Harris, to learn more.
+
+## Speaker
+
+- Dan Harris, CEO & Founder, Neurodiversity in Business
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2023/september/hybrid-event-neurodiversity-in-business-how-can-you-help-it/).*

--- a/docs/events/2023-10-hidden-risks-of-edi-data.md
+++ b/docs/events/2023-10-hidden-risks-of-edi-data.md
@@ -1,0 +1,27 @@
+# Neurodiversity: hidden risks of Equity, Diversity and Inclusion (EDI) data
+
+**Tuesday 10 October 2023, 6:00pm – 7:45pm · Webinar · with the IRMA specialist group**
+
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/jzncgMudXpE" title="Neurodiversity, hidden risks of Equity, Diversity and Inclusion (EDI) data | IRMA SG" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+Many organisations are waking up to the benefits that a truly diverse workforce can bring. In order to manage this process, there is an increasing pressure to collect and publish data on a range of different categories of personal data.
+
+This presents a particular risk for members of "hidden" or "invisible" minority groups, such as neurodivergent people, LQBTQ+ people, and others whose minority status may not be obvious from day-to-day workplace interactions.
+
+This talk will explore:
+
+- The concept of neurodiversity and its benefit to organisations
+- What kind of data is being collected for EDI-related activities and why
+- What "hidden" monitory status really means, and why special care must be taken with data relating to it.
+- How to work with and collect such data more safely and effectively
+
+This presentation is based on the paper "Worthy of trust: Protecting minority privacy in diversity reporting", originally published in the Journal of Data Protection & Privacy.
+
+## Speaker
+
+- Matthew Bellringer, innovation and impact guide, speaker and author; Chair and co-founder of NeurodiverseIT
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2023/october/webinar-neurodiversity-hidden-risks-of-equity-diversity-and-inclusion-edi-data/).*

--- a/docs/events/2023-10-who-when-and-how-to-share.md
+++ b/docs/events/2023-10-who-when-and-how-to-share.md
@@ -1,0 +1,15 @@
+# Who, when and how to share — a personal and professional dilemma
+
+**Monday 30 October 2023, 6:30pm · Webinar**
+
+Disclosing neurodivergence in a professional setting may facilitate positive adaptations but also be associated with negative stigma. Neurodivergent people may feel pressured to disclose even when it's against their interests.
+
+The discussion will focus on the experiences of those in that situation and considerations around disclosure, including the factors either way which might help someone consider their position.
+
+## Speakers
+
+- Eric Heath, neurodiversity researcher and consultant; member of the Autonomy group
+- Matthew Bellringer, Chair of NeurodiverseIT (welcome)
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2023/october/webinar-who-when-and-how-to-share-a-personal-and-professional-dilemma/).*

--- a/docs/events/2024-01-experiences-of-disability-and-neurodiversity-in-it.md
+++ b/docs/events/2024-01-experiences-of-disability-and-neurodiversity-in-it.md
@@ -1,0 +1,20 @@
+# Experiences of disability and neurodiversity in IT
+
+**Tuesday 16 January 2024, 12:30pm – 1:15pm · Webinar**
+
+A specialist panel explores the contribution that disabled and neurodivergent people make to the profession, and what can be done to allow those groups to contribute even more.
+
+The issues disabled and neurodivergent people face not only impacts individuals but prevents people from contributing to the profession in ways that benefit the whole of society. The discussion will cover:
+
+- Understanding and mitigating barriers to using technology and working in the IT profession itself
+- The role of assistive technology, attitudes of employers, and tips for employers and employees on providing effective support
+- The wider benefits for those people who don't identify as disabled – the kerb-cut phenomenon - everyone's physical, sensory and cognitive abilities vary, and by improving matters for people with greater needs in an area, we improve things for everyone
+
+The discussion will be approximately 30 minutes, with questions at the end.
+
+## Host
+
+- Matthew Bellringer, BCS NeurodiverseIT specialist group (chair)
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2024/january/webinar-experiences-of-disability-and-neurodiversity-in-it/).*

--- a/docs/events/2024-04-digital-for-all-leeds.md
+++ b/docs/events/2024-04-digital-for-all-leeds.md
@@ -1,0 +1,19 @@
+# Digital for all: Building a connected digital inclusion ecosystem in Leeds
+
+**Tuesday 16 April 2024, 5:00pm – 6:00pm · Webinar · with the Digital Divide specialist group**
+
+Closing the digital divide requires joined up thinking and action. This webinar showcases how the city of Leeds drives digital inclusion, led by the council's ambition to build a compassionate city that tackles poverty and reduces inequalities.
+
+We are delighted to have Amy Hearn, Digital Inclusion Manager for 100% Digital Leeds, sharing how Leeds is building a coordinated and connected digital inclusion ecosystem across Leeds – working with the third sector, public sector, health and care, and tech sector – to strengthen digital inclusion infrastructure in communities to increase access, engagement and participation.
+
+Come and learn from 100% Digital Leeds leading one of the most successful digital inclusion programmes in the UK.
+
+## Speakers
+
+- Amy Hearn, Digital Inclusion Manager, 100% Digital Leeds
+- Freddie Quek, Chair of the BCS Digital Divide specialist group (host)
+
+*This event was hosted by the Digital Divide specialist group and supported by BCS Hampshire, Dorset Branch, BCSWomen and NeurodiverseIT.*
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2024/april/webinar-digital-for-all-building-a-connected-digital-inclusion-ecosystem-in-leeds/).*

--- a/docs/events/2024-04-neurodivergence-and-tech-entrepreneurship.md
+++ b/docs/events/2024-04-neurodivergence-and-tech-entrepreneurship.md
@@ -1,0 +1,18 @@
+# Neurodivergence and Tech Entrepreneurship
+
+**Monday 22 April 2024, 6:30pm – 8:00pm · Webinar**
+
+Traditional models of employment don't suit everyone. There are barriers in normal workplaces and recruiters assume standard qualifications and education. Entrepreneurship may be a viable alternative. It provides more autonomy and suits those with the qualities of being brave and not afraid to try. It allows someone to create a workspace under their control. There are tangible rewards, for example for someone who likes to make their own things. It also uses the creative abilities common with neurodivergent people. Yet this comes with financial insecurity, anxiety of the unknown and needing to pitch to investors. These sorts of issues will be explored.
+
+## Agenda
+
+- 6:30pm — Introduction
+- 6:45pm — Main presentation
+- 8:00pm — End of event
+
+## Speaker
+
+- David Lane, IT Director specialising in Digital Transformation and CyberSecurity, with a focus on small and medium businesses
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2024/april/webinar-neurodivergence-and-tech-entrepreneurship/).*

--- a/docs/events/2024-04-neurodiverseit-agm.md
+++ b/docs/events/2024-04-neurodiverseit-agm.md
@@ -1,0 +1,23 @@
+# BCS NeurodiverseIT specialist group AGM
+
+**Tuesday 9 April 2024, 6:00pm – 7:00pm · Webinar**
+
+We are holding our AGM to confirm the committee for the 2023/24 year.
+
+We will be carrying over some existing members, and confirming recently co-opted members of the committee. If you're interested in volunteering yourself, please contact Matthew using the email address below.
+
+Please note that voting is for BCS Member Only.
+
+## Agenda
+
+- 6:00pm — AGM starts (welcome, apologies, last year's minutes, Chair's letter, Treasurer's report, committee positions voting, any other business)
+- 7:00pm — Close of AGM
+
+Roles up for election include: Chair, Treasurer, Content officer, Member secretary, Industry liaison / publicity officer, Inclusion officer, Early Careers, Education liaison.
+
+## Host
+
+- Matthew Bellringer, Chair, BCS NeurodiverseIT specialist group
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2024/april/webinar-bcs-neurodiverseit-specialist-group-agm/).*

--- a/docs/events/2024-05-countering-dyslexia-with-llms.md
+++ b/docs/events/2024-05-countering-dyslexia-with-llms.md
@@ -1,0 +1,16 @@
+# Countering dyslexia adverse effects with Large Language Models like ChatGPT
+
+**Wednesday 15 May 2024, 7:30pm – 9:00pm · Webinar · with the BCS Oxfordshire branch**
+
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/WOpdoxa9rY4" title="Countering Dyslexia Adverse Effects with Large Language Models (LLMs) like ChatGPT | Oxfordshire" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+Explore the transformative power of technology in overcoming dyslexia challenges. Join Antonio Hidalgo-Landa for an insightful talk on leveraging Large Language Models (LLMs) to support learning differences. Discover how these innovations are reshaping education and accessibility. This session invites you to ponder the evolving role of technology in learning and its potential implications. Antonio will share practical strategies that harness LLMs to mitigate dyslexia's impact. This discussion also prompts us to consider the evolving role of technology in education. As we delve into the possibilities of LLMs, let's ponder: Could there be a future where relying on machines alters the dynamics of creative thinking? Be part of this engaging conversation and broaden your perspective on education and technology. Your input and feedback on these techniques are invaluable. We're eager to connect with those who can benefit and learn from your experiences too. Join us for an engaging discussion that offers a fresh perspective on learning, technology, and empowerment.
+
+## Speaker
+
+- Antonio Hidalgo-Landa, Senior Technical Account Manager and Chair of the BCS Consultancy specialist group
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2024/may/webinar-countering-dyslexia-adverse-effects-with-large-language-models-like-chatgpt/).*

--- a/docs/events/2024-06-autism-and-the-it-profession-buckland-report.md
+++ b/docs/events/2024-06-autism-and-the-it-profession-buckland-report.md
@@ -1,0 +1,29 @@
+# Autism and the IT profession — a response to The Buckland Report
+
+**Thursday 20 June 2024, 6:00pm – 7:30pm · Webinar**
+
+Co-producing a community response.
+
+The Government's Buckland Report on autism and employment was published earlier this year. In this event, we will create a response to the report from the perspective of the IT professionals in our community.
+
+The UK government commissioned the Buckland Report in 2023 to address the barriers and disincentives resulting in low numbers of autistic people in employment. By conducting a series of consultations, gathering other inputs and leveraging the support of Autistica's resources, it came up with recommendations on the following themes:
+
+- Initiatives to raise awareness, reduce stigma and capitalise on productivity
+- Supporting autistic people to begin or return to a career
+- Recruitment practices that appropriately support autistic applicants
+- Supporting autistic people already in the workforce
+- Encouraging and supporting career progression
+
+This event aims to explore these themes in the context of the IT profession and the BCS to produce an article on the topic that will be submitted to the BCS blog and magazine. We will have an introduction to the Buckland Report from Marc Goblot, a NeuroDiverseIT committee member who participated in consultations.
+
+We will then explore each theme in small groups and reconvene to discuss what each group has found. You will be asked to contribute to the discussion and creation of the final document to the degree you feel comfortable doing so. You do not need any particular expertise in the area.
+
+The purpose of this approach is to make sure that our response is as broadly representative as possible.
+
+## Speakers
+
+- Matthew Bellringer, Chair, BCS NeurodiverseIT specialist group (host)
+- Marc Goblot, NeurodiverseIT committee member (introducing the Buckland Report)
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2024/june/webinar-autism-and-the-it-profession-a-response-to-the-buckland-report/).*

--- a/docs/events/2024-12-neurodiversity-and-ai.md
+++ b/docs/events/2024-12-neurodiversity-and-ai.md
@@ -1,0 +1,19 @@
+# Neurodiversity and AI
+
+**Tuesday 3 December 2024, 6:00pm – 7:30pm · Webinar**
+
+AI has seen a huge increase in use in the last few years. It is fulfilling more and more functions in work and everyday life. This opens up new possibilities for neurodivergent people to work and be supported. It also poses new risks that disadvantage and increase marginalisation.
+
+AI tools can be of significant benefit to neurodivergent people. From grammar and tone checkers to LLM guided processes, there are already many such tools on the market. There are even more promising products likely available in the new future. AI has the capacity to increase inclusion and remove barriers to fully participating in society.
+
+Despite these potential benefits, the increased use of AI also poses a significant threat to the neurodivergent community. Automated decision-making can fail to take into account individual capabilities, and bias can become incredibly hard to identify. AI has the capacity to further exacerbate and amplify existing barriers, making full participation in society even harder.
+
+To address this, some members of NeurodiverseIT along with other stakeholders, are forming a working group, Neurodiversity and AI, to look examine and raise awareness of the issues involved. We hope to nudge the development of AI in a more neurodiversity-supporting direction. In this meeting we will lay out the main issues as we see them, share a little about who is in the group, and share how you can get involved yourself.
+
+## Speakers
+
+- Antonio Hidalgo-Landa
+- Beckett LeClair
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2024/december/webinar-neurodiversity-and-ai/).*

--- a/docs/events/2025-01-neurodiverseit-agm.md
+++ b/docs/events/2025-01-neurodiverseit-agm.md
@@ -1,0 +1,18 @@
+# NeurodiverseIT AGM
+
+**Wednesday 22 January 2025, 6:00pm – 7:30pm · Webinar**
+
+The Annual General Meeting of the NeurodiverseIT Specialist Group, where we elect committee members and set priorities for the coming year.
+
+We are holding our AGM for the committee for the 2024/25 year and to set priorities for the coming year in the NeurodiverseIT group. It's a great chance to find out more and get involved in the running of our specialist group. We will be carrying over some existing members, and confirming recently co-opted members of the committee. If you're interested in volunteering yourself (whether you're a BCS member or not), please contact Matthew using the email address below.
+
+We will be voting on the following roles at the meeting: Chair, Vice-chair, Treasurer, Publicity, Secretary, Inclusion officer, Early Careers Advocate, Learning & Development Officer, Accessibility Officer, Other committee members.
+
+## Agenda
+
+- 6:00pm — AGM welcome (apologies, last year's minutes, Chair's letter, Treasurer's report, Inclusion Officer's report, Early Career Advocate report, committee positions voting, any other business)
+- 7:00pm — Priorities for the coming year — open discussion
+- 7:30pm — Close
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2025/january/webinar-neurodiverseit-agm/).*

--- a/docs/events/2025-02-neurodiversity-in-the-it-profession.md
+++ b/docs/events/2025-02-neurodiversity-in-the-it-profession.md
@@ -1,0 +1,39 @@
+# Neurodiversity in the IT Profession
+
+**Thursday 20 February 2025, 6:00pm – 7:30pm · In person · with the BCS South Yorkshire Branch**
+
+*Sheffield Hallam University, City Campus, Cantor Building, Room 9130, Sheffield S1 2ND.*
+
+Learn from neurodivergent professionals who have developed careers in IT, and how we all can make the IT industry more inclusive.
+
+Many neurodivergent professionals have developed successful careers in the Tech Industry, and find creative solutions and utilise unique skills to solve business challenges faced by many businesses and delivering a competitive advantage.
+
+There are still barriers though for neurodivergent professionals who wish to develop a career in the Tech Industry, and a report titled "The Experiences of NeuroDiverese and Disabled people in IT", published by the BCS in 2023, highlights some of these barriers many neurodivergent professionals face, including some stigmas that still exist.
+
+This event consists of a panel of neurodiverse professionals who consist of:
+
+- Andrew Shaw
+- Matthew Bellringer
+- Maddy Kilby-McMurray
+- Damo Quinn
+- Jess Burden
+- Jonathan Ellwood
+
+Who will deliver lightning talks about there experiences whilst developing careers in the Tech Industry.
+
+Following the lightning talks, there will be a panel discussion about how neurodivergent professionals can develop their careers and reach their potential, including the following questions:
+
+- The barriers to neurodivergent professionals developing their careers in the Tech Industry?
+- How we as a community can make the Tech Industry more accessible and more inclusive?
+
+## Panellists
+
+- Andrew Shaw, neurodivergent software testing professional; Diversity and Inclusion officer, BCS South Yorkshire branch; editor, Tester online magazine (BCS Software Testing SIG)
+- Matthew Bellringer, MBCS MBPsS, neurodiversity and innovation specialist; Chair and Co-founder, NeurodiverseIT; founder, Curious Being community
+- Maddy Kilby-McMurray, QA Non-Functional Test Analyst, Rail Delivery Group; Inclusion Officer, BCS SIGiST
+- Damo Quinn, author, "Finding a Voice"; Developmental Language Disorder awareness advocate
+- Jess Burden, Security Engineer, IASME; organiser, Worcester Defcon
+- Jonathan Ellwood, Head of Cyber Incident Exercising and Response, IASME Consortium; Visiting Fellow, University of Gloucestershire
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2025/february/neurodiversity-in-the-it-profession/).*

--- a/docs/events/2025-03-iwd-sigist-thought-leadership-in-testing.md
+++ b/docs/events/2025-03-iwd-sigist-thought-leadership-in-testing.md
@@ -1,0 +1,23 @@
+# Celebrating IWD with BCS SIGiST – Thought Leadership in Testing
+
+**Monday 10 March 2025, 6:00pm – 8:15pm · Webinar · with the Software Testing specialist group (SIGiST)**
+
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/pEeqMlIrHXs" title="Celebrating IWD with BCS SIGiST – Thought Leadership in Testing | Software Testing SG" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+On International Women's Day, BCS SIGiST has brought together an inspiring lineup of speakers to celebrate and discuss the theme of Thought Leadership in Software Testing. This event will highlight the critical role of women in shaping the future of quality engineering, emphasizing innovation, influence, and leadership in the industry. Of course we are keeping this as diverse and inclusive as well.
+
+Thought leadership is not just about expertise, it's about driving change, challenging norms, and inspiring the next generation. As the testing landscape evolves with AI, automation, and data-driven strategies, the voices and contributions of women in technology are more important than ever.
+
+This event will serve as a powerful platform for sharing experiences, insights, and strategies that push the boundaries of testing and quality engineering. It will reinforce the importance of diversity, mentorship, and continuous learning, ensuring that women in tech continue to lead, innovate, and thrive.
+
+## Speakers
+
+- Suman Bala, award-winning Quality Advocate
+- Andy Shaw, Technology Industry Professional, BCS Activities
+- Jonathon Wright, Chief Technology Officer, Strategic Thought Leader
+- Gomathi Ramalingam, Director of QA and Product Delivery, SIMBA Chain
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2025/march/webinar-celebrating-iwd-with-bcs-sigist-thought-leadership-in-testing/).*

--- a/docs/events/2025-06-digital-vs-ai-literacy.md
+++ b/docs/events/2025-06-digital-vs-ai-literacy.md
@@ -1,0 +1,28 @@
+# Digital vs AI Literacy: Are We Closing the Right Divide?
+
+**Thursday 12 June 2025, 5:00pm – 6:00pm · Webinar · with the Digital Divide specialist group**
+
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/bZmj1wBlooE" title="Digital vs AI Literacy: Are We Closing the Right Divide? | Digital Divide SG" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+As AI transforms how we live and work, is digital literacy still enough? This webinar explores the evolving skills gap, questioning whether traditional digital skills prepare us for an AI-driven world.
+
+Join us to unpack the differences between digital and AI literacy—and what's truly needed to close the divide.
+
+The panel examines the growing corporate imperative to upskill employees in AI literacy (required by the European AI Act), exploring whether meaningful compliance means basic online training or developing comprehensive programs that truly prepare workforces.
+
+The panel will also define what this new competency entails—from understanding AI fundamentals to critical evaluation skills—and discuss the varying depths of knowledge needed across different organisational roles.
+
+## Speakers and panellists
+
+- Freddie Quek (host)
+- Delphine Charlotte (panel chair)
+- Rebena Sanghera, High Performance Skills Coach, WorldSkills UK
+- Lucy Caton, Lead Centre of AI in Education, University of Greater Manchester
+- Paul Finnis, former CEO Digital Poverty Alliance; Co-Director, The NextPath Device Consortium
+
+*This event was hosted by the Digital Divide specialist group and supported by BCS Hampshire, Dorset Branch, NeurodiverseIT and BCSWomen.*
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2025/june/webinar-digital-vs-ai-literacy-are-we-closing-the-right-divide/).*

--- a/docs/events/2025-10-starting-a-neurodiversity-erg.md
+++ b/docs/events/2025-10-starting-a-neurodiversity-erg.md
@@ -1,0 +1,41 @@
+# Starting a Neurodiversity ERG
+
+**Thursday 30 October 2025, 4:00pm – 5:30pm · Webinar**
+
+<div class="video">
+  <iframe src="https://www.youtube-nocookie.com/embed/mwBUdxUzm8k" title="Starting an neurodiversity ERG | NeurodiverseIT SG" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+Employee Resource Groups (ERGs) or Affinity Groups are a popular way of supporting marginalised and minoritised people in organisations.
+
+Whilst many organisations have ERGs for women and people of colour, far fewer have those for disabled and/or neurodivergent people. Of those that do, many of those groups are quite new. In this event, or panellists will share experiences of setting up such groups in different organisations.
+
+You will learn what's worked and what hasn't in a range of circumstances, and how to approach setting up an ERG in your own organisation.
+
+The topics we will explore include:
+
+- Making the case for an ERG internally
+- Finding volunteers
+- Getting a charter
+- setting governance/purpose
+- Deciding who can join
+- Exec sponsorship and representation
+- Finding allies or supporting as an ally
+- Structure/cadence/ritual/targets
+- Running your first session
+- Sources of support out there for people setting up an ERG.
+
+Please join us if you are interested in supporting neurodiversity in your own organisation.
+
+We will start with a roundtable discussion featuring the panellists, and then have a chance for winder discussion and questions with all attendees.
+
+## Panellists
+
+- Laura Harris, Database Manager at Pepper Money UK
+- Aurora Pakenham-Smith, Director, Site Reliability Engineering at Kevel
+- Beckett LeClair, Head of Compliance at 5Rights
+- Karthik Raghuraman, Global Digital Learning Lead at Cognizant
+- Matthew Bellringer, Chair of NeurodiverseIT (host)
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2025/october/webinar-starting-an-neurodiversity-erg/).*

--- a/docs/events/2026-02-neurodiverseit-agm.md
+++ b/docs/events/2026-02-neurodiverseit-agm.md
@@ -1,0 +1,26 @@
+# NeurodiverseIT AGM
+
+**Wednesday 25 February 2026, 6:00pm – 7:30pm · Webinar**
+
+Our Special Interest Group AGM is where we vote on committee members and set priorities for the coming year.
+
+We are holding our AGM for the committee for the 2025/26 year, and to set priorities for the coming year in the NeurodiverseIT group. It's a great chance to find out more and get involved in the running of our specialist group.
+
+We will be carrying over some existing members and confirming recently co-opted members of the committee.
+
+## Agenda
+
+- 6:00pm — AGM
+    - Welcome and apologies
+    - Last year's minutes
+    - Chair's letter
+    - Treasurer's report
+    - Inclusion Officer's report
+    - Early Career Advocate report
+    - Committee positions voting
+    - Any other business
+- 7:00pm — Priorities for the coming year — open discussion
+- 7:30pm — Event ends
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2026/february/webinar-agm/).*

--- a/docs/events/2026-05-embracing-neurodiversity-and-the-future-of-project-teams.md
+++ b/docs/events/2026-05-embracing-neurodiversity-and-the-future-of-project-teams.md
@@ -1,0 +1,36 @@
+# Embracing Neurodiversity and the Future of Project Teams
+
+**Tuesday 19 May 2026, 6:30pm · Hybrid event · with the Project Management specialist group (PROMS-G)**
+
+Learn how to use neurodiversity to your advantage in effective project delivery.
+
+Neurodiversity reflects natural differences in how people think, communicate and approach problem-solving.
+
+In project and programme environments, recognising and supporting these differences is essential for ethical practice, talent development and effective team performance.
+
+This highly relevant event will examine what is neurodiversity and why it is important to understand (including ethical considerations).
+
+We will examine:
+
+- How to identify neurodiversity in people (especially young people).
+- How to harness neurodiversity including any techniques/professional experience.
+- How to make a project team function inclusively and effectively with neurodiverse members (including use of emotional intelligence).
+
+Our speaker will explain why research is important and the relevance of other diversities (e.g. cultural/ethnic). This will be followed by an interactive panel session bringing together research, project practice and HR/training perspectives, drawing on work linked to the Association for Project Management (APM).
+
+Panellists will discuss how neurodiversity may present in the workplace, particularly among students, graduates and early-career professionals and how it can be identified in a respectful, non-diagnostic way.
+
+Through discussion and professional examples, the panel will explore practical techniques for harnessing neurodiverse strengths, including inclusive task design, communication approaches and leadership behaviours.
+
+The session will also examine how project teams can function more inclusively and effectively, highlighting the role of emotionally intelligent leadership and the contribution of HR and learning and development professionals in creating supportive, psychologically safe project environments.
+
+This session is relevant for early-career project professionals, practitioners, and those involved in people development and team leadership.
+
+## Speakers and panellists
+
+- Lydia Adigun, Course Director for Programme and Project Management, Assistant Professor, Warwick Manufacturing Group, University of Warwick (speaker)
+- Matthew Bellringer, MBCS MBPsS, neurodiversity and innovation specialist; Chair and Co-founder of NeurodiverseIT
+- Nicola Martin, FBCS, Founder of NMC&C, Chair of BCS SIGiST, Early Careers Advocate for NeurodiverseIT
+
+---
+*Originally published by [BCS](https://www.bcs.org/events-calendar/2026/may/hybrid-embracing-neurodiversity-and-the-future-of-project-teams/).*

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -15,3 +15,32 @@
   height: 100%;
   border: 0;
 }
+
+/* Each event on the listing page is rendered as a distinct card. */
+.md-typeset .event-card {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.3rem;
+  padding: 0.6rem 1rem 0.8rem;
+  margin: 1rem 0;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.md-typeset .event-card > :first-child {
+  margin-top: 0;
+}
+
+.md-typeset .event-card > :last-child {
+  margin-bottom: 0;
+}
+
+/* Tighten the gap between the event title and its meta line. */
+.md-typeset .event-card h3 {
+  margin-bottom: 0;
+}
+
+/* Date / format / co-host meta line under each event title. */
+.md-typeset .event-card .event-meta {
+  margin: 0.1rem 0 0.4rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.8rem;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,17 @@
+/* Responsive 16:9 wrapper for embedded YouTube recordings on event pages. */
+.video {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  margin: 1em 0;
+}
+
+.video iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "BCS NeurodiverseIT community site (MkDocs Material)";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        # Mirrors what CI installs (`pip install mkdocs-material`), but reproducibly.
+        # Build:  nix develop -c mkdocs build --strict
+        # Serve:  nix develop -c mkdocs serve
+        default = pkgs.mkShell {
+          packages = [
+            (pkgs.python3.withPackages (ps: [ ps.mkdocs-material ]))
+          ];
+        };
+      });
+    };
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,3 +11,11 @@ nav:
       - 'What is ADHD?': 'adhd.md'
       - 'What is Autism?': 'autism.md'
       - 'What is Dyslexia?': 'dyslexia.md'
+  - 'Events': 'events.md'
+
+# The per-event post pages are reached from the Events listing, not the nav.
+not_in_nav: |
+  events/*.md
+
+extra_css:
+  - stylesheets/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,3 +19,7 @@ not_in_nav: |
 
 extra_css:
   - stylesheets/extra.css
+
+markdown_extensions:
+  - md_in_html
+  - attr_list


### PR DESCRIPTION
Closes #13.

Adds a first-class **Events** section reproducing the BCS NeurodiverseIT specialist group's 28 past events on the community site. The BCS listing only shows title/date/time and never embeds the webinar recordings (those live separately on the BCS Member Groups YouTube channel) — this surfaces the full archive in one place, with recordings embedded where they exist.

## What's included
- `docs/events.md` — listing grouped by year (newest first); each event = title + date + one-line blurb linking to its post page.
- `docs/events/<YYYY-MM-slug>.md` — 28 event post pages, each with the BCS abstract, speaker/panellist list, a link back to the canonical BCS page, and an **embedded YouTube recording where one was confirmed**.
- `docs/stylesheets/extra.css` — responsive 16:9 wrapper for the embeds.
- `mkdocs.yml` — `Events` nav entry, `not_in_nav: events/*.md` (post pages reached via the listing, not the nav), `extra_css`.
- `flake.nix` / `flake.lock` — reproducible dev shell (`nix develop -c mkdocs build --strict`), mirroring what CI installs.

## Recordings embedded (8 confirmed)
Starting a Neurodiversity ERG (the one called out in #13), Digital vs AI Literacy, IWD/SIGiST, Countering dyslexia with LLMs, EDI data risks, Digital divide for the visually impaired, Business Change, and Neurodiversity Understood. Each was matched by title on the relevant hosting SG's official channel.

## Notes for review
- **One unverified video match** to confirm before merge: *Closing the Digital Divide AGM* (23 Feb 2023) — candidate `youtube.com/watch?v=PMRkp77iv20` could be a different Digital Divide SG talk, so it was **left out** rather than guessed. Add it if you can confirm.
- Abstracts are reproduced verbatim from BCS (including a few source typos, e.g. "winder discussion", "formally launch"). The two AGM agendas were lightly reformatted from BCS's layout.
- *Autism — Harnessing my super power* (Apr 2022): BCS didn't expose the speaker's name cleanly, so the speaker is described by role only.

Builds clean with `mkdocs build --strict` (28 pages + listing, links and embeds all resolve).
